### PR TITLE
feat(ui): SMS review polish — ATM tag, decimals, toast redirect, currency dropdowns

### DIFF
--- a/apps/mobile/app/sms-review.tsx
+++ b/apps/mobile/app/sms-review.tsx
@@ -127,20 +127,14 @@ export default function SmsReviewScreen(): React.JSX.Element {
             ]
           );
         } else {
-          Alert.alert(
-            "Success",
-            `Saved ${result.savedCount} transaction${result.savedCount !== 1 ? "s" : ""} from SMS!`,
-            [
-              {
-                text: "View Transactions",
-                onPress: () => {
-                  markSyncComplete().catch(console.error);
-                  clearTransactions();
-                  router.replace("/(tabs)");
-                },
-              },
-            ]
-          );
+          showToast({
+            type: "success",
+            title: "Saved!",
+            message: `Saved ${result.savedCount} transaction${result.savedCount !== 1 ? "s" : ""} from SMS!`,
+          });
+          markSyncComplete().catch(console.error);
+          clearTransactions();
+          router.replace("/(tabs)/transactions");
         }
 
         // Notify user if ATM withdrawals were skipped (FR-007)

--- a/apps/mobile/components/sms-sync/SenderAccountMapper.tsx
+++ b/apps/mobile/components/sms-sync/SenderAccountMapper.tsx
@@ -212,7 +212,7 @@ export function SenderAccountMapper({
     () =>
       accounts.map((a) => ({
         value: a.key,
-        label: a.name,
+        label: `${a.name} (${a.currency})`,
       })),
     [accounts]
   );

--- a/apps/mobile/components/sms-sync/SmsTransactionEditModal.tsx
+++ b/apps/mobile/components/sms-sync/SmsTransactionEditModal.tsx
@@ -154,7 +154,7 @@ export function SmsTransactionEditModal({
 
   const handleSelectAccount = useCallback((acc: AccountWithBankDetails) => {
     setSelectedAccountId(acc.id);
-    setSelectedAccountName(acc.name);
+    setSelectedAccountName(`${acc.name} (${acc.currency})`);
     setIsAccountPickerOpen(false);
   }, []);
 
@@ -349,7 +349,7 @@ export function SmsTransactionEditModal({
                             : "text-slate-300"
                         }`}
                       >
-                        {acc.name}
+                        {acc.name} ({acc.currency})
                       </Text>
                       {acc.id === selectedAccountId && (
                         <Ionicons

--- a/apps/mobile/components/sms-sync/SmsTransactionItem.tsx
+++ b/apps/mobile/components/sms-sync/SmsTransactionItem.tsx
@@ -16,12 +16,16 @@
  * @module SmsTransactionItem
  */
 
+import { palette } from "@/constants/colors";
+import { formatCurrency, ParsedSmsTransaction } from "@astik/logic";
+import { Ionicons } from "@expo/vector-icons";
 import React, { useCallback, useState } from "react";
 import { Pressable, Text, View } from "react-native";
-import Animated, { FadeIn, FadeOut, Layout } from "react-native-reanimated";
-import { Ionicons } from "@expo/vector-icons";
-import { palette } from "@/constants/colors";
-import type { ParsedSmsTransaction } from "@astik/logic";
+import Animated, {
+  FadeIn,
+  FadeOut,
+  LinearTransition,
+} from "react-native-reanimated";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -43,14 +47,6 @@ interface SmsTransactionItemProps {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Format a number as currency string */
-function formatAmount(amount: number): string {
-  return amount.toLocaleString("en-EG", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-}
 
 /** Format a Date as "dd MMM" */
 function formatDate(date: Date): string {
@@ -92,7 +88,7 @@ export function SmsTransactionItem({
 
   return (
     <Animated.View
-      layout={Layout.springify()}
+      layout={LinearTransition.springify()}
       className="bg-slate-800/60 rounded-2xl mb-3 overflow-hidden"
     >
       <Pressable
@@ -129,7 +125,7 @@ export function SmsTransactionItem({
               {transaction.isAtmWithdrawal && (
                 <View className="bg-amber-500/20 px-1.5 py-0.5 rounded ml-2">
                   <Text className="text-[10px] font-bold text-amber-400">
-                    ATM
+                    Cash Withdrawal
                   </Text>
                 </View>
               )}
@@ -147,7 +143,10 @@ export function SmsTransactionItem({
               }`}
             >
               {isExpense ? "-" : "+"}
-              {formatAmount(transaction.amount)} {transaction.currency}
+              {formatCurrency({
+                amount: transaction.amount,
+                currency: transaction.currency,
+              })}
             </Text>
           </View>
 

--- a/apps/mobile/services/sms-account-matcher.ts
+++ b/apps/mobile/services/sms-account-matcher.ts
@@ -17,7 +17,7 @@
  * @module sms-account-matcher
  */
 
-import { Account, BankDetails, database } from "@astik/db";
+import { Account, BankDetails, database, type CurrencyType } from "@astik/db";
 import type { ParsedSmsTransaction } from "@astik/logic";
 import { Q } from "@nozbe/watermelondb";
 
@@ -40,6 +40,7 @@ interface AccountMatch {
 interface AccountWithBankDetails {
   readonly id: string;
   readonly name: string;
+  readonly currency: CurrencyType;
   readonly isDefault: boolean;
   readonly smsSenderName?: string;
   readonly cardLast4?: string;
@@ -83,6 +84,7 @@ async function fetchAccountsWithDetails(
     results.push({
       id: account.id,
       name: account.name,
+      currency: account.currency,
       isDefault: account.isDefault,
       smsSenderName: bankDetails?.smsSenderName ?? undefined,
       cardLast4: bankDetails?.cardLast4 ?? undefined,


### PR DESCRIPTION
## Summary

4 focused UI fixes for the SMS transaction review flow.

## Related Issues

- Closes #66
- Closes #59
- Closes #60
- Closes #57

## Changes

### #66 — Rename "ATM" tag to "Cash Withdrawal"
- [SmsTransactionItem.tsx](cci:7://file:///e:/Work/My%20Projects/Astik/apps/mobile/components/sms-sync/SmsTransactionItem.tsx:0:0-0:0): Tag text changed from "ATM" to "Cash Withdrawal"

### #59 — Remove decimals for whole numbers
- [SmsTransactionItem.tsx](cci:7://file:///e:/Work/My%20Projects/Astik/apps/mobile/components/sms-sync/SmsTransactionItem.tsx:0:0-0:0): Replaced local `formatAmount` (forced `.00`) with [formatCurrency](cci:1://file:///e:/Work/My%20Projects/Astik/packages/logic/src/utils/currency.ts:70:0-123:2) from `@astik/logic` (0 fraction digits by default)

### #60 — Replace blocking Alert with Toast + auto-redirect
- [sms-review.tsx](cci:7://file:///e:/Work/My%20Projects/Astik/apps/mobile/app/sms-review.tsx:0:0-0:0): Success `Alert.alert` → `showToast` + auto-redirect to `/(tabs)/transactions`
- Partial-save and discard Alerts preserved (user needs to acknowledge errors)

### #57 — Display currency next to account name in dropdowns
- [SmsTransactionEditModal.tsx](cci:7://file:///e:/Work/My%20Projects/Astik/apps/mobile/components/sms-sync/SmsTransactionEditModal.tsx:0:0-0:0): Account picker shows `Name (Currency)` format
- [SenderAccountMapper.tsx](cci:7://file:///e:/Work/My%20Projects/Astik/apps/mobile/components/sms-sync/SenderAccountMapper.tsx:0:0-0:0): Channel mapping dropdown shows `Name (Currency)`
- [sms-account-matcher.ts](cci:7://file:///e:/Work/My%20Projects/Astik/apps/mobile/services/sms-account-matcher.ts:0:0-0:0): Added `currency` field to [AccountWithBankDetails](cci:2://file:///e:/Work/My%20Projects/Astik/apps/mobile/services/sms-account-matcher.ts:39:0-46:1) interface

## Files Changed (5)
- [apps/mobile/components/sms-sync/SmsTransactionItem.tsx](cci:7://file:///e:/Work/My%20Projects/Astik/apps/mobile/components/sms-sync/SmsTransactionItem.tsx:0:0-0:0)
- [apps/mobile/app/sms-review.tsx](cci:7://file:///e:/Work/My%20Projects/Astik/apps/mobile/app/sms-review.tsx:0:0-0:0)
- [apps/mobile/services/sms-account-matcher.ts](cci:7://file:///e:/Work/My%20Projects/Astik/apps/mobile/services/sms-account-matcher.ts:0:0-0:0)
- [apps/mobile/components/sms-sync/SmsTransactionEditModal.tsx](cci:7://file:///e:/Work/My%20Projects/Astik/apps/mobile/components/sms-sync/SmsTransactionEditModal.tsx:0:0-0:0)
- `apps/mobile/components/sms-sync/SenderAccountMapper.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account selections now display currency alongside account names for improved clarity.

* **Improvements**
  * Success notifications now use non-blocking toast messages instead of modal alerts.
  * Transaction labels updated for clarity (e.g., "ATM" changed to "Cash Withdrawal").
  * Direct navigation to transactions tab after successful save.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->