### PR TITLE
fix: address remaining PR #114 review comments (batch 2)

### DIFF
--- a/apps/mobile/__tests__/services/edit-account-service.test.ts
+++ b/apps/mobile/__tests__/services/edit-account-service.test.ts
@@ -498,6 +498,18 @@ describe("edit-account-service", () => {
     });
 
     it("should create INCOME transaction when balance increases", async () => {
+      // Capture the created transaction to verify type and category
+      let createdTx: Record<string, unknown> | undefined;
+      mockDb.get.mockImplementation((tableName: string) => ({
+        create: jest.fn(
+          (builder: (r: Record<string, unknown>) => void) => {
+            createdTx = { id: `new-${tableName}-${Date.now()}` };
+            builder(createdTx);
+            return Promise.resolve(createdTx);
+          }
+        ),
+      }));
+
       const result = await createBalanceAdjustmentTransaction(
         "acc-1",
         "user-1",
@@ -505,11 +517,30 @@ describe("edit-account-service", () => {
         1000,
         1500
       );
+
       expect(result.success).toBe(true);
       expect(mockDb.write).toHaveBeenCalled();
+      expect(createdTx).toBeDefined();
+      expect(createdTx?.type).toBe("INCOME");
+      expect(createdTx?.categoryId).toBe(
+        "00000000-0000-0000-0001-000000000200"
+      );
+      expect(createdTx?.amount).toBe(500);
     });
 
     it("should create EXPENSE transaction when balance decreases", async () => {
+      // Capture the created transaction to verify type and category
+      let createdTx: Record<string, unknown> | undefined;
+      mockDb.get.mockImplementation((tableName: string) => ({
+        create: jest.fn(
+          (builder: (r: Record<string, unknown>) => void) => {
+            createdTx = { id: `new-${tableName}-${Date.now()}` };
+            builder(createdTx);
+            return Promise.resolve(createdTx);
+          }
+        ),
+      }));
+
       const result = await createBalanceAdjustmentTransaction(
         "acc-1",
         "user-1",
@@ -517,12 +548,30 @@ describe("edit-account-service", () => {
         1500,
         1000
       );
+
       expect(result.success).toBe(true);
       expect(mockDb.write).toHaveBeenCalled();
+      expect(createdTx).toBeDefined();
+      expect(createdTx?.type).toBe("EXPENSE");
+      expect(createdTx?.categoryId).toBe(
+        "00000000-0000-0000-0001-000000000201"
+      );
+      expect(createdTx?.amount).toBe(500);
     });
 
     it("should use absolute difference as amount", async () => {
       // The transaction amount should be positive regardless of direction
+      let createdTx: Record<string, unknown> | undefined;
+      mockDb.get.mockImplementation((tableName: string) => ({
+        create: jest.fn(
+          (builder: (r: Record<string, unknown>) => void) => {
+            createdTx = { id: `new-${tableName}-${Date.now()}` };
+            builder(createdTx);
+            return Promise.resolve(createdTx);
+          }
+        ),
+      }));
+
       await createBalanceAdjustmentTransaction(
         "acc-1",
         "user-1",
@@ -530,8 +579,11 @@ describe("edit-account-service", () => {
         1000,
         700
       );
+
       // Verify write was called — the created transaction amount = |700 - 1000| = 300
       expect(mockDb.write).toHaveBeenCalled();
+      expect(createdTx).toBeDefined();
+      expect(createdTx?.amount).toBe(300);
     });
 
     it("should return error on database failure", async () => {

--- a/apps/mobile/components/edit-account/BalanceChangedSheet.tsx
+++ b/apps/mobile/components/edit-account/BalanceChangedSheet.tsx
@@ -28,6 +28,16 @@ import {
 import { palette } from "@/constants/colors";
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Size for the header swap-vertical icon. */
+const HEADER_ICON_SIZE = 28;
+
+/** Size for the arrow-forward icon between balance values. */
+const ARROW_ICON_SIZE = 18;
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -90,9 +100,18 @@ export function BalanceChangedSheet({
 
   const difference = newBalance - previousBalance;
   const isIncrease = difference > 0;
-  const changeLabel = isIncrease ? "Increase" : "Decrease";
-  const changeColor = isIncrease ? palette.nileGreen[500] : palette.red[500];
-  const changeSign = isIncrease ? "+" : "-";
+  const isDecrease = difference < 0;
+  const changeLabel = isIncrease
+    ? "Increase"
+    : isDecrease
+      ? "Decrease"
+      : "No Change";
+  const changeColor = isIncrease
+    ? palette.nileGreen[500]
+    : isDecrease
+      ? palette.red[500]
+      : palette.slate[500];
+  const changeSign = isIncrease ? "+" : isDecrease ? "-" : "";
 
   return (
     <Modal
@@ -121,7 +140,7 @@ export function BalanceChangedSheet({
                   <View className="w-14 h-14 rounded-full bg-amber-100 dark:bg-amber-500/20 justify-center items-center mb-3">
                     <Ionicons
                       name="swap-vertical"
-                      size={28}
+                      size={HEADER_ICON_SIZE}
                       color={palette.gold[500]}
                     />
                   </View>
@@ -147,7 +166,7 @@ export function BalanceChangedSheet({
                     </View>
                     <Ionicons
                       name="arrow-forward"
-                      size={18}
+                      size={ARROW_ICON_SIZE}
                       color={isDark ? palette.slate[500] : palette.slate[400]}
                     />
                     <View className="flex-1 items-end">

--- a/apps/mobile/components/edit-account/ReadOnlyDropdown.tsx
+++ b/apps/mobile/components/edit-account/ReadOnlyDropdown.tsx
@@ -20,6 +20,16 @@ import { palette } from "@/constants/colors";
 import { useTheme } from "@/context/ThemeContext";
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Duration in milliseconds before the tooltip auto-hides. */
+const TOOLTIP_AUTO_HIDE_MS = 3000;
+
+/** Duration in milliseconds for tooltip fade animations. */
+const TOOLTIP_FADE_DURATION_MS = 200;
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -129,7 +139,7 @@ export function ReadOnlyDropdown({
       // Hide tooltip with fade out
       Animated.timing(tooltipOpacity, {
         toValue: 0,
-        duration: 200,
+        duration: TOOLTIP_FADE_DURATION_MS,
         useNativeDriver: true,
       }).start(() => setShowTooltip(false));
     } else {
@@ -137,18 +147,18 @@ export function ReadOnlyDropdown({
       setShowTooltip(true);
       Animated.timing(tooltipOpacity, {
         toValue: 1,
-        duration: 200,
+        duration: TOOLTIP_FADE_DURATION_MS,
         useNativeDriver: true,
       }).start();
 
-      // Auto-hide after 3 seconds
+      // Auto-hide after configured duration
       timeoutRef.current = setTimeout(() => {
         Animated.timing(tooltipOpacity, {
           toValue: 0,
-          duration: 200,
+          duration: TOOLTIP_FADE_DURATION_MS,
           useNativeDriver: true,
         }).start(() => setShowTooltip(false));
-      }, 3000);
+      }, TOOLTIP_AUTO_HIDE_MS);
     }
   }, [showTooltip, tooltipOpacity]);
 

--- a/specs/001-edit-delete-account/checklists/requirements.md
+++ b/specs/001-edit-delete-account/checklists/requirements.md
@@ -3,7 +3,7 @@
 **Purpose**: Validate specification completeness and quality before proceeding
 to planning  
 **Created**: 2026-03-18  
-**Feature**: [spec.md](file:///E:/Work/My%20Projects/Astik/specs/001-edit-delete-account/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 


### PR DESCRIPTION
## Summary

Addresses remaining CodeRabbit nitpick/minor comments from PR #114 that were not covered in the first fix batch (PR #117).

## Changes

### `BalanceChangedSheet.tsx`
- Extracted magic icon sizes to named constants (`HEADER_ICON_SIZE`, `ARROW_ICON_SIZE`)
- Added tri-state handling for `difference === 0` edge case — shows "No Change" label with neutral `palette.slate[500]` color instead of misleading "Decrease"

### `ReadOnlyDropdown.tsx`
- Extracted tooltip timing magic numbers to named constants (`TOOLTIP_AUTO_HIDE_MS`, `TOOLTIP_FADE_DURATION_MS`)

### `requirements.md`
- Replaced broken `file:///` absolute path with repository-relative link `../spec.md`

### `edit-account-service.test.ts`
- Enhanced `createBalanceAdjustmentTransaction` tests: INCOME/EXPENSE tests now capture the created transaction and assert `type`, `categoryId`, and `amount` instead of only verifying `mockDb.write` was called

## Related

- Parent PR: #114
- Previous fix batch: #117