### PR TITLE
fix: address PR #118 code review findings (P0 + P1)

### DIFF
--- a/apps/mobile/components/ui/Skeleton.tsx
+++ b/apps/mobile/components/ui/Skeleton.tsx
@@ -15,8 +15,14 @@
  */
 
 import { LinearGradient } from "expo-linear-gradient";
-import React, { useEffect, useRef } from "react";
-import { Animated, type StyleProp, View, type ViewStyle } from "react-native";
+import React, { useCallback, useState } from "react";
+import { type LayoutChangeEvent, type StyleProp, View, type ViewStyle } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
 
 import { palette } from "@/constants/colors";
 import { useTheme } from "@/context/ThemeContext";
@@ -54,10 +60,8 @@ const SHIMMER_COLORS = {
   },
 } as const;
 
-const SHIMMER_GRADIENT_STYLE: ViewStyle = {
-  flex: 1,
-  width: 400,
-};
+/** Multiplier for gradient width relative to container width */
+const GRADIENT_WIDTH_MULTIPLIER = 2;
 
 // ---------------------------------------------------------------------------
 // Component
@@ -86,25 +90,23 @@ export function Skeleton({
   style,
 }: SkeletonProps): React.JSX.Element {
   const { isDark } = useTheme();
-  const shimmerTranslate = useRef(new Animated.Value(-1)).current;
+  const shimmerPosition = useSharedValue(-1);
+  const [containerWidth, setContainerWidth] = useState(0);
 
   const colors = isDark ? SHIMMER_COLORS.dark : SHIMMER_COLORS.light;
 
-  useEffect(() => {
-    const animation = Animated.loop(
-      Animated.timing(shimmerTranslate, {
-        toValue: 1,
-        duration: ANIMATION_DURATION_MS,
-        useNativeDriver: true,
-      })
+  // Start the shimmer animation
+  React.useEffect(() => {
+    shimmerPosition.value = withRepeat(
+      withTiming(1, { duration: ANIMATION_DURATION_MS }),
+      -1, // infinite repeat
+      false // no reverse
     );
+  }, [shimmerPosition]);
 
-    animation.start();
-
-    return (): void => {
-      animation.stop();
-    };
-  }, [shimmerTranslate]);
+  const handleLayout = useCallback((event: LayoutChangeEvent): void => {
+    setContainerWidth(event.nativeEvent.layout.width);
+  }, []);
 
   const containerStyle: ViewStyle = {
     width: width as number,
@@ -114,24 +116,35 @@ export function Skeleton({
     overflow: "hidden",
   };
 
-  const translateX = shimmerTranslate.interpolate({
-    inputRange: [-1, 1],
-    outputRange: [-200, 200],
-  });
+  const gradientWidth = containerWidth > 0
+    ? containerWidth * GRADIENT_WIDTH_MULTIPLIER
+    : 0;
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      {
+        translateX: containerWidth > 0
+          ? shimmerPosition.value * containerWidth
+          : 0,
+      },
+    ],
+  }));
+
+  const gradientContainerStyle: ViewStyle = {
+    flex: 1,
+    width: gradientWidth,
+  };
 
   return (
-    <View style={[containerStyle, style]}>
+    <View style={[containerStyle, style]} onLayout={handleLayout}>
       <Animated.View
-        style={{
-          flex: 1,
-          transform: [{ translateX }],
-        }}
+        style={[{ flex: 1 }, animatedStyle]}
       >
         <LinearGradient
           colors={[colors.base, colors.highlight, colors.base]}
           start={{ x: 0, y: 0.5 }}
           end={{ x: 1, y: 0.5 }}
-          style={SHIMMER_GRADIENT_STYLE}
+          style={gradientContainerStyle}
         />
       </Animated.View>
     </View>

--- a/apps/mobile/components/ui/Tooltip.tsx
+++ b/apps/mobile/components/ui/Tooltip.tsx
@@ -20,7 +20,13 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Animated, Pressable, Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
+import ReanimatedAnimated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+  runOnJS,
+} from "react-native-reanimated";
 
 import { palette } from "@/constants/colors";
 import { useTheme } from "@/context/ThemeContext";
@@ -161,7 +167,7 @@ export function Tooltip({
   animationDurationMs = DEFAULT_ANIMATION_DURATION_MS,
 }: TooltipProps): React.JSX.Element | null {
   const { isDark } = useTheme();
-  const opacityRef = useRef(new Animated.Value(0));
+  const opacity = useSharedValue(0);
   const [isRendered, setIsRendered] = useState(false);
   const autoDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
@@ -179,33 +185,33 @@ export function Tooltip({
   useEffect(() => {
     if (visible) {
       setIsRendered(true);
-      Animated.timing(opacityRef.current, {
-        toValue: 1,
-        duration: animationDurationMs,
-        useNativeDriver: true,
-      }).start();
+      opacity.value = withTiming(1, { duration: animationDurationMs });
 
       if (autoDismissMs > 0) {
         clearAutoDismissTimer();
         autoDismissTimerRef.current = setTimeout(() => {
-          Animated.timing(opacityRef.current, {
-            toValue: 0,
-            duration: animationDurationMs,
-            useNativeDriver: true,
-          }).start(() => {
-            setIsRendered(false);
-            onDismiss();
-          });
+          opacity.value = withTiming(
+            0,
+            { duration: animationDurationMs },
+            (finished) => {
+              if (finished) {
+                runOnJS(setIsRendered)(false);
+                runOnJS(onDismiss)();
+              }
+            }
+          );
         }, autoDismissMs);
       }
     } else {
-      Animated.timing(opacityRef.current, {
-        toValue: 0,
-        duration: animationDurationMs,
-        useNativeDriver: true,
-      }).start(() => {
-        setIsRendered(false);
-      });
+      opacity.value = withTiming(
+        0,
+        { duration: animationDurationMs },
+        (finished) => {
+          if (finished) {
+            runOnJS(setIsRendered)(false);
+          }
+        }
+      );
     }
 
     return clearAutoDismissTimer;
@@ -215,12 +221,16 @@ export function Tooltip({
     animationDurationMs,
     onDismiss,
     clearAutoDismissTimer,
+    opacity,
   ]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
 
   const tooltipStyle = useMemo(
     () => ({
       ...getTooltipBaseStyle(position),
-      opacity: opacityRef.current,
       backgroundColor: tooltipBgColor,
     }),
     [position, tooltipBgColor]
@@ -241,7 +251,7 @@ export function Tooltip({
   }
 
   return (
-    <Animated.View style={tooltipStyle}>
+    <ReanimatedAnimated.View style={[tooltipStyle, animatedStyle]}>
       <Pressable onPress={onDismiss}>
         <Text
           className="text-xs font-medium"
@@ -251,6 +261,6 @@ export function Tooltip({
         </Text>
       </Pressable>
       <View style={arrowStyle} />
-    </Animated.View>
+    </ReanimatedAnimated.View>
   );
 }

--- a/apps/mobile/hooks/useMetalHoldings.ts
+++ b/apps/mobile/hooks/useMetalHoldings.ts
@@ -18,7 +18,20 @@ import { useEffect, useMemo, useState } from "react";
 import { Q } from "@nozbe/watermelondb";
 
 import { Asset, AssetMetal, database, type CurrencyType } from "@astik/db";
-import { convertCurrency, getMetalPriceUsd } from "@astik/logic";
+import { convertCurrency } from "@astik/logic";
+
+import {
+  enrichHolding,
+  groupAndSortHoldings,
+  computePortfolioSplit,
+  joinAssetsWithMetals,
+  PERCENTAGE_MULTIPLIER,
+} from "../services/metal-holding-calculations";
+import type {
+  MetalHolding,
+  PortfolioSplit,
+  ProfitLoss,
+} from "../services/metal-holding-calculations";
 
 import { useMarketRates } from "./useMarketRates";
 import { usePreferredCurrency } from "./usePreferredCurrency";
@@ -27,41 +40,11 @@ import { usePreferredCurrency } from "./usePreferredCurrency";
 // Types
 // ---------------------------------------------------------------------------
 
-/** A metal holding enriched with computed values for display */
-interface MetalHolding {
-  /** The parent Asset record */
-  readonly asset: Asset;
-  /** The child AssetMetal record */
-  readonly assetMetal: AssetMetal;
-  /** Current market value in user's preferred currency */
-  readonly currentValue: number;
-  /** Current market value in USD */
-  readonly currentValueUsd: number;
-  /** Profit/loss as a percentage ((current - purchase) / purchase * 100) */
-  readonly profitLossPercent: number;
-  /** Absolute profit/loss amount in preferred currency */
-  readonly profitLossAmount: number;
-}
-
 /** Summary for a single metal type */
 interface MetalTypeSummary {
   readonly totalValue: number;
   readonly percentage: number;
   readonly itemCount: number;
-}
-
-/** Portfolio split between metal types */
-interface PortfolioSplit {
-  readonly gold: MetalTypeSummary;
-  readonly silver: MetalTypeSummary;
-}
-
-/** Aggregate profit/loss for the entire portfolio */
-interface ProfitLoss {
-  /** Absolute profit/loss amount in preferred currency */
-  readonly amount: number;
-  /** Profit/loss as a percentage */
-  readonly percent: number;
 }
 
 interface UseMetalHoldingsResult {
@@ -79,149 +62,6 @@ interface UseMetalHoldingsResult {
   readonly portfolioSplit: PortfolioSplit;
   /** Whether the data is still loading */
   readonly isLoading: boolean;
-}
-
-// ---------------------------------------------------------------------------
-// Internal Types (raw DB data before enrichment)
-// ---------------------------------------------------------------------------
-
-interface RawHolding {
-  readonly asset: Asset;
-  readonly assetMetal: AssetMetal;
-}
-
-// ---------------------------------------------------------------------------
-// Helper Functions
-// ---------------------------------------------------------------------------
-
-/**
- * Joins assets with their corresponding asset_metals records.
- * Each asset is expected to have exactly one asset_metal child.
- */
-function joinAssetsWithMetals(
-  assets: readonly Asset[],
-  assetMetals: readonly AssetMetal[]
-): readonly RawHolding[] {
-  const metalsByAssetId = new Map<string, AssetMetal>();
-
-  for (const metal of assetMetals) {
-    metalsByAssetId.set(metal.assetId, metal);
-  }
-
-  const holdings: RawHolding[] = [];
-
-  for (const asset of assets) {
-    const assetMetal = metalsByAssetId.get(asset.id);
-    if (assetMetal) {
-      holdings.push({ asset, assetMetal });
-    }
-  }
-
-  return holdings;
-}
-
-/**
- * Enriches a raw holding with computed market values and profit/loss.
- */
-function enrichHolding(
-  raw: RawHolding,
-  latestRates: NonNullable<Parameters<typeof getMetalPriceUsd>[1]>,
-  preferredCurrency: CurrencyType
-): MetalHolding {
-  const pricePerGramUsd = getMetalPriceUsd(
-    raw.assetMetal.metalType,
-    latestRates
-  );
-  const currentValueUsd = raw.assetMetal.calculateValue(pricePerGramUsd);
-  const currentValue =
-    preferredCurrency === "USD"
-      ? currentValueUsd
-      : convertCurrency(currentValueUsd, "USD", preferredCurrency, latestRates);
-
-  const purchasePriceInPref =
-    raw.asset.currency === preferredCurrency
-      ? raw.asset.purchasePrice
-      : convertCurrency(
-          raw.asset.purchasePrice,
-          raw.asset.currency,
-          preferredCurrency,
-          latestRates
-        );
-
-  const profitLossAmount = currentValue - purchasePriceInPref;
-  const profitLossPercent =
-    purchasePriceInPref > 0
-      ? (profitLossAmount / purchasePriceInPref) * 100
-      : 0;
-
-  return {
-    asset: raw.asset,
-    assetMetal: raw.assetMetal,
-    currentValue,
-    currentValueUsd,
-    profitLossPercent,
-    profitLossAmount,
-  };
-}
-
-/**
- * Sort comparator: newest purchase date first (descending).
- * FR-024: Holdings sorted by purchase date descending.
- */
-function sortByPurchaseDateDesc(a: MetalHolding, b: MetalHolding): number {
-  return b.asset.purchaseDate.getTime() - a.asset.purchaseDate.getTime();
-}
-
-/**
- * Group enriched holdings by metal type and sort by purchase date desc.
- */
-function groupAndSortHoldings(holdings: readonly MetalHolding[]): {
-  gold: MetalHolding[];
-  silver: MetalHolding[];
-} {
-  const gold: MetalHolding[] = [];
-  const silver: MetalHolding[] = [];
-
-  for (const holding of holdings) {
-    if (holding.assetMetal.metalType === "GOLD") {
-      gold.push(holding);
-    } else if (holding.assetMetal.metalType === "SILVER") {
-      silver.push(holding);
-    }
-  }
-
-  gold.sort(sortByPurchaseDateDesc);
-  silver.sort(sortByPurchaseDateDesc);
-
-  return { gold, silver };
-}
-
-/**
- * Compute portfolio split percentages.
- */
-function computePortfolioSplit(
-  goldHoldings: readonly MetalHolding[],
-  silverHoldings: readonly MetalHolding[],
-  totalValue: number
-): PortfolioSplit {
-  const goldTotal = goldHoldings.reduce((sum, h) => sum + h.currentValue, 0);
-  const silverTotal = silverHoldings.reduce(
-    (sum, h) => sum + h.currentValue,
-    0
-  );
-
-  return {
-    gold: {
-      totalValue: goldTotal,
-      percentage: totalValue > 0 ? (goldTotal / totalValue) * 100 : 0,
-      itemCount: goldHoldings.length,
-    },
-    silver: {
-      totalValue: silverTotal,
-      percentage: totalValue > 0 ? (silverTotal / totalValue) * 100 : 0,
-      itemCount: silverHoldings.length,
-    },
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -269,7 +109,9 @@ export function useMetalHoldings(): UseMetalHoldingsResult {
         setAssets(result);
       },
       error: (err: unknown) => {
-        console.error("Error observing metal assets:", err);
+        // TODO: Replace with structured logging when logging infrastructure is added
+        console.error("[useMetalHoldings] Error observing metal assets:", err);
+        setDataLoading(false);
       },
     });
 
@@ -287,7 +129,8 @@ export function useMetalHoldings(): UseMetalHoldingsResult {
         setDataLoading(false);
       },
       error: (err: unknown) => {
-        console.error("Error observing asset metals:", err);
+        // TODO: Replace with structured logging when logging infrastructure is added
+        console.error("[useMetalHoldings] Error observing asset metals:", err);
         setDataLoading(false);
       },
     });
@@ -322,25 +165,17 @@ export function useMetalHoldings(): UseMetalHoldingsResult {
     // 3. Group and sort (FR-024: newest first)
     const { gold, silver } = groupAndSortHoldings(enriched);
 
-    // 4. Compute aggregates
+    // 4. Compute aggregates (using pre-computed purchasePriceInPref from enrichHolding)
     const totalValue = enriched.reduce((sum, h) => sum + h.currentValue, 0);
-    const totalPurchasePrice = enriched.reduce((sum, h) => {
-      const purchaseInPref =
-        h.asset.currency === preferredCurrency
-          ? h.asset.purchasePrice
-          : convertCurrency(
-              h.asset.purchasePrice,
-              h.asset.currency,
-              preferredCurrency,
-              latestRates
-            );
-      return sum + purchaseInPref;
-    }, 0);
+    const totalPurchasePrice = enriched.reduce(
+      (sum, h) => sum + h.purchasePriceInPref,
+      0
+    );
 
     const profitLossAmount = totalValue - totalPurchasePrice;
     const profitLossPercent =
       totalPurchasePrice > 0
-        ? (profitLossAmount / totalPurchasePrice) * 100
+        ? (profitLossAmount / totalPurchasePrice) * PERCENTAGE_MULTIPLIER
         : 0;
 
     // 5. Portfolio split

--- a/apps/mobile/services/metal-holding-calculations.ts
+++ b/apps/mobile/services/metal-holding-calculations.ts
@@ -1,0 +1,232 @@
+/**
+ * Metal Holding Calculations
+ *
+ * Pure computation functions for metal holdings — enrichment, grouping,
+ * sorting, and portfolio split. Extracted from the hook layer to comply
+ * with Constitution IV (Service-Layer Separation): hooks handle lifecycle
+ * only; business calculations live in the service/utility layer.
+ *
+ * Architecture & Design Rationale:
+ * - Pattern: Pure Functions (Functional Core)
+ * - Why: These functions are pure data transforms with no side-effects.
+ *   Extracting them makes them testable, reusable, and keeps the hook thin.
+ * - SOLID: SRP — each function does one thing (enrich, group, split).
+ *
+ * @module metal-holding-calculations
+ */
+
+import type { Asset, AssetMetal, CurrencyType } from "@astik/db";
+import { convertCurrency, getMetalPriceUsd } from "@astik/logic";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Multiplier to convert a ratio (0–1) to a percentage (0–100) */
+const PERCENTAGE_MULTIPLIER = 100;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Raw DB data before enrichment */
+interface RawHolding {
+  readonly asset: Asset;
+  readonly assetMetal: AssetMetal;
+}
+
+/** A metal holding enriched with computed values for display */
+interface MetalHolding {
+  /** The parent Asset record */
+  readonly asset: Asset;
+  /** The child AssetMetal record */
+  readonly assetMetal: AssetMetal;
+  /** Current market value in user's preferred currency */
+  readonly currentValue: number;
+  /** Current market value in USD */
+  readonly currentValueUsd: number;
+  /** Purchase price converted to preferred currency */
+  readonly purchasePriceInPref: number;
+  /** Profit/loss as a percentage ((current - purchase) / purchase * 100) */
+  readonly profitLossPercent: number;
+  /** Absolute profit/loss amount in preferred currency */
+  readonly profitLossAmount: number;
+}
+
+/** Summary for a single metal type */
+interface MetalTypeSummary {
+  readonly totalValue: number;
+  readonly percentage: number;
+  readonly itemCount: number;
+}
+
+/** Portfolio split between metal types */
+interface PortfolioSplit {
+  readonly gold: MetalTypeSummary;
+  readonly silver: MetalTypeSummary;
+}
+
+/** Aggregate profit/loss for the entire portfolio */
+interface ProfitLoss {
+  /** Absolute profit/loss amount in preferred currency */
+  readonly amount: number;
+  /** Profit/loss as a percentage */
+  readonly percent: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helper Functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Joins assets with their corresponding asset_metals records.
+ * Each asset is expected to have exactly one asset_metal child.
+ */
+function joinAssetsWithMetals(
+  assets: readonly Asset[],
+  assetMetals: readonly AssetMetal[]
+): readonly RawHolding[] {
+  const metalsByAssetId = new Map<string, AssetMetal>();
+
+  for (const metal of assetMetals) {
+    metalsByAssetId.set(metal.assetId, metal);
+  }
+
+  const holdings: RawHolding[] = [];
+
+  for (const asset of assets) {
+    const assetMetal = metalsByAssetId.get(asset.id);
+    if (assetMetal) {
+      holdings.push({ asset, assetMetal });
+    }
+  }
+
+  return holdings;
+}
+
+/**
+ * Enriches a raw holding with computed market values and profit/loss.
+ */
+function enrichHolding(
+  raw: RawHolding,
+  latestRates: NonNullable<Parameters<typeof getMetalPriceUsd>[1]>,
+  preferredCurrency: CurrencyType
+): MetalHolding {
+  const pricePerGramUsd = getMetalPriceUsd(
+    raw.assetMetal.metalType,
+    latestRates
+  );
+  const currentValueUsd = raw.assetMetal.calculateValue(pricePerGramUsd);
+  const currentValue =
+    preferredCurrency === "USD"
+      ? currentValueUsd
+      : convertCurrency(currentValueUsd, "USD", preferredCurrency, latestRates);
+
+  const purchasePriceInPref =
+    raw.asset.currency === preferredCurrency
+      ? raw.asset.purchasePrice
+      : convertCurrency(
+          raw.asset.purchasePrice,
+          raw.asset.currency,
+          preferredCurrency,
+          latestRates
+        );
+
+  const profitLossAmount = currentValue - purchasePriceInPref;
+  const profitLossPercent =
+    purchasePriceInPref > 0
+      ? (profitLossAmount / purchasePriceInPref) * PERCENTAGE_MULTIPLIER
+      : 0;
+
+  return {
+    asset: raw.asset,
+    assetMetal: raw.assetMetal,
+    currentValue,
+    currentValueUsd,
+    purchasePriceInPref,
+    profitLossPercent,
+    profitLossAmount,
+  };
+}
+
+/**
+ * Sort comparator: newest purchase date first (descending).
+ * FR-024: Holdings sorted by purchase date descending.
+ */
+function sortByPurchaseDateDesc(a: MetalHolding, b: MetalHolding): number {
+  return b.asset.purchaseDate.getTime() - a.asset.purchaseDate.getTime();
+}
+
+/**
+ * Group enriched holdings by metal type and sort by purchase date desc.
+ */
+function groupAndSortHoldings(holdings: readonly MetalHolding[]): {
+  gold: MetalHolding[];
+  silver: MetalHolding[];
+} {
+  const gold: MetalHolding[] = [];
+  const silver: MetalHolding[] = [];
+
+  for (const holding of holdings) {
+    if (holding.assetMetal.metalType === "GOLD") {
+      gold.push(holding);
+    } else if (holding.assetMetal.metalType === "SILVER") {
+      silver.push(holding);
+    }
+  }
+
+  gold.sort(sortByPurchaseDateDesc);
+  silver.sort(sortByPurchaseDateDesc);
+
+  return { gold, silver };
+}
+
+/**
+ * Compute portfolio split percentages.
+ */
+function computePortfolioSplit(
+  goldHoldings: readonly MetalHolding[],
+  silverHoldings: readonly MetalHolding[],
+  totalValue: number
+): PortfolioSplit {
+  const goldTotal = goldHoldings.reduce((sum, h) => sum + h.currentValue, 0);
+  const silverTotal = silverHoldings.reduce(
+    (sum, h) => sum + h.currentValue,
+    0
+  );
+
+  return {
+    gold: {
+      totalValue: goldTotal,
+      percentage:
+        totalValue > 0
+          ? (goldTotal / totalValue) * PERCENTAGE_MULTIPLIER
+          : 0,
+      itemCount: goldHoldings.length,
+    },
+    silver: {
+      totalValue: silverTotal,
+      percentage:
+        totalValue > 0
+          ? (silverTotal / totalValue) * PERCENTAGE_MULTIPLIER
+          : 0,
+      itemCount: silverHoldings.length,
+    },
+  };
+}
+
+export {
+  joinAssetsWithMetals,
+  enrichHolding,
+  groupAndSortHoldings,
+  computePortfolioSplit,
+  PERCENTAGE_MULTIPLIER,
+};
+
+export type {
+  RawHolding,
+  MetalHolding,
+  MetalTypeSummary,
+  PortfolioSplit,
+  ProfitLoss,
+};

--- a/apps/mobile/services/metal-holding-service.ts
+++ b/apps/mobile/services/metal-holding-service.ts
@@ -56,6 +56,41 @@ interface CreateMetalHoldingData {
 }
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MIN_PURITY_FRACTION = 0;
+const MAX_PURITY_FRACTION = 1;
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates the input data for creating a metal holding.
+ * Throws a descriptive error if any domain rule is violated.
+ */
+function validateCreateMetalHoldingData(
+  data: CreateMetalHoldingData
+): void {
+  if (data.name.trim().length === 0) {
+    throw new Error("Holding name is required");
+  }
+  if (data.weightGrams <= 0) {
+    throw new Error("Weight must be greater than 0");
+  }
+  if (data.purchasePrice < 0) {
+    throw new Error("Purchase price cannot be negative");
+  }
+  if (
+    data.purityFraction <= MIN_PURITY_FRACTION ||
+    data.purityFraction > MAX_PURITY_FRACTION
+  ) {
+    throw new Error("Purity fraction must be in the range (0, 1]");
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Service Functions
 // ---------------------------------------------------------------------------
 
@@ -65,11 +100,13 @@ interface CreateMetalHoldingData {
  *
  * @param data - The metal holding data to create
  * @returns The created Asset record
- * @throws Error if user is not authenticated or if the write fails
+ * @throws Error if user is not authenticated, validation fails, or if the write fails
  */
 async function createMetalHolding(
   data: CreateMetalHoldingData
 ): Promise<Asset> {
+  validateCreateMetalHoldingData(data);
+
   const userId = await getCurrentUserId();
   if (!userId) {
     throw new Error("User not authenticated");
@@ -82,7 +119,7 @@ async function createMetalHolding(
     // 1. Create the parent Asset record
     const asset = await assetsCollection.create((record) => {
       record.userId = userId;
-      record.name = data.name;
+      record.name = data.name.trim();
       record.type = "METAL";
       record.purchasePrice = data.purchasePrice;
       record.purchaseDate = data.purchaseDate;

--- a/specs/018-metals-page-redesign/tasks.md
+++ b/specs/018-metals-page-redesign/tasks.md
@@ -26,7 +26,7 @@
 component
 
 - [ ] T002 [P] Create SQL migration
-      `supabase/migrations/024_gold_silver_purity_enums.sql` — define
+      `supabase/migrations/034_gold_silver_purity_enums.sql` — define
       `gold_karat_enum` (24, 22, 21, 18, 14, 10) and `silver_fineness_enum`
       (999, 950, 925, 900, 850, 800) Postgres enums as SSOT for purity options
 - [ ] T003 [P] Verify and update `packages/logic/src/utils/purity-utils.ts` —
@@ -287,7 +287,7 @@ T013         (US5: Add modal)
 
 | Metric                      | Value                                             |
 | --------------------------- | ------------------------------------------------- |
-| **Total tasks**             | 22                                                |
+| **Total tasks**             | 21                                                |
 | **Setup**                   | 1 task                                            |
 | **Schema & Infrastructure** | 4 tasks (enums, purity verify, Tooltip, Skeleton) |
 | **Foundational**            | 2 tasks (service + hook)                          |


### PR DESCRIPTION
## 🔧 Fixes for PR #118 Code Review

Addresses all **P0 (Must Fix)** and **P1 (Should Fix)** findings from the code review.

### Changes

#### P0 Fixes (Bugs / Constitution Violations)
- **`Skeleton.tsx`**: Migrated shimmer animation from `react-native` Animated → `react-native-reanimated` (Constitution V compliance)
- **`Tooltip.tsx`**: Migrated fade animation from `react-native` Animated → `react-native-reanimated` with `runOnJS` callbacks
- **`useMetalHoldings.ts`**: Fixed error handler not clearing loading state (stuck in loading on asset query failure)
- **`metal-holding-service.ts`**: Added `validateCreateMetalHoldingData()` with checks for name, weight, price, and purity

#### P1 Fixes (DRY / Code Quality)
- **NEW `metal-holding-calculations.ts`**: Extracted all business logic from `useMetalHoldings` hook into pure functions — `enrichHolding()`, `computePortfolioSplit()`, `groupAndSortHoldings()`, `joinAssetsWithMetals()`
- **`useMetalHoldings.ts`**: Simplified to lifecycle-only hook that delegates to calculation functions; added `purchasePriceInPref` to `MetalHolding` interface to eliminate duplicate currency conversion; extracted `PERCENTAGE_MULTIPLIER` constant
- **`Skeleton.tsx`**: Added `onLayout`-based dynamic shimmer width instead of hardcoded `400px`

#### P2 Fixes (Docs)
- **`tasks.md`**: Fixed migration filename `024_` → `034_`, corrected total task count from 22 → 21

### Review Reference
See the detailed review comment on PR #118 for the full triage table and rationale.