### PR TITLE
fix(budgets): address code review findings C1, C2, M1, M2, M3

### DIFF
--- a/apps/mobile/hooks/useBudgetDetail.ts
+++ b/apps/mobile/hooks/useBudgetDetail.ts
@@ -177,13 +177,15 @@ export function useBudgetDetail(budgetId: string): UseBudgetDetailResult {
           .fetch();
 
         for (const child of children) {
+          // M1 fix: Include L3 (grandchild) transactions in subcategory breakdown
+          const childCategoryIds = await getCategoryAndSubcategoryIds(child.id);
           const allChildTxs = await database
             .get<Transaction>("transactions")
             .query(
               Q.and(
                 Q.where("deleted", false),
                 Q.where("type", "EXPENSE"),
-                Q.where("category_id", child.id),
+                Q.where("category_id", Q.oneOf(childCategoryIds)),
                 Q.where("date", Q.gte(bounds.start.getTime())),
                 Q.where("date", Q.lte(bounds.end.getTime()))
               )

--- a/apps/mobile/services/budget-service.ts
+++ b/apps/mobile/services/budget-service.ts
@@ -131,14 +131,25 @@ export async function updateBudget(
 ): Promise<Budget> {
   const budget = await budgetsCollection().find(budgetId);
 
-  // Type-specific validation for period changes
+  // Type-specific validation for period changes (C1 fix: correct operator precedence)
+  const effectivePeriod = input.period ?? budget.period;
   if (
-    ((input.period ?? budget.period) === "CUSTOM" &&
-      !(input.periodStart ?? budget.periodStart)) ||
-    !(input.periodEnd ?? budget.periodEnd)
+    effectivePeriod === "CUSTOM" &&
+    (!(input.periodStart ?? budget.periodStart) ||
+      !(input.periodEnd ?? budget.periodEnd))
   ) {
     throw new Error(
       "Custom period budgets require both periodStart and periodEnd"
+    );
+  }
+
+  // Re-validate uniqueness if period or categoryId changed (C2 fix)
+  if (input.period !== undefined || input.categoryId !== undefined) {
+    await validateBudgetUniqueness(
+      budget.type,
+      input.period ?? budget.period,
+      input.categoryId ?? budget.categoryId,
+      budgetId
     );
   }
 
@@ -187,6 +198,11 @@ export async function deleteBudget(budgetId: string): Promise<void> {
 export async function pauseBudget(budgetId: string): Promise<void> {
   const budget = await budgetsCollection().find(budgetId);
 
+  // M2 fix: Guard against pausing an already-paused budget
+  if (budget.status === "PAUSED") {
+    throw new Error("Budget is already paused");
+  }
+
   await database.write(async () => {
     await budget.update((b) => {
       b.status = "PAUSED" as BudgetStatus;
@@ -202,6 +218,12 @@ export async function pauseBudget(budgetId: string): Promise<void> {
  */
 export async function resumeBudget(budgetId: string): Promise<void> {
   const budget = await budgetsCollection().find(budgetId);
+
+  // M3 fix: Guard against resuming a non-paused budget
+  if (budget.status !== "PAUSED") {
+    throw new Error("Cannot resume a budget that is not paused");
+  }
+
   const pausedAtMs = budget.pausedAtMs;
   const nowMs = Date.now();
 


### PR DESCRIPTION
## Code Review Fixes for PR #132

Fixes 5 issues identified during the code review of the Budget Management feature.

### Checklist

- [x] **C1** — Fix operator precedence bug in `updateBudget` validation (`budget-service.ts`)
  - The `||` had lower precedence than `&&`, causing the `periodEnd` check to apply to ALL budgets, not just CUSTOM. Extracted `effectivePeriod` and corrected parentheses.

- [x] **C2** — Add `validateBudgetUniqueness` call in `updateBudget` (`budget-service.ts`)
  - When `period` or `categoryId` changes during an update, uniqueness is now re-validated with `excludeBudgetId` to prevent duplicate budgets.

- [x] **M1** — Include L3 (grandchild) transactions in subcategory breakdown (`useBudgetDetail.ts`)
  - Previously queried only `category_id = child.id`, missing grandchild transactions. Now uses `getCategoryAndSubcategoryIds(child.id)` for consistency with `getSpendingForBudget`.

- [x] **M2** — Add guard to `pauseBudget` (`budget-service.ts`)
  - Prevents double-pausing which would overwrite `pausedAt`, corrupting pause interval tracking.

- [x] **M3** — Add guard to `resumeBudget` (`budget-service.ts`)
  - Prevents resuming already-active budgets, avoiding empty interval writes.

### Deferred (Minor)

- `validateBudgetUniqueness` race condition (outside `database.write()`) — low probability, can be addressed later
- Unused `baseQuery` variable cleanup
- Extract alert rollover reset to service logic
- Service-layer unit tests