### PR TITLE
fix: voice recording auto-stop not transitioning to completed state (#165)

### DIFF
--- a/apps/mobile/hooks/useVoiceTransactionFlow.ts
+++ b/apps/mobile/hooks/useVoiceTransactionFlow.ts
@@ -17,7 +17,7 @@
  * @module useVoiceTransactionFlow
  */
 
-import { useCallback, useState, useRef } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { router } from "expo-router";
 import { useVoiceRecorder } from "./useVoiceRecorder";
 import {
@@ -105,6 +105,21 @@ export function useVoiceTransactionFlow(
   }, []);
 
   // ---------------------------------------------------------------------------
+  // Sync recorder auto-stop to flow status (FR-004)
+  // ---------------------------------------------------------------------------
+  // When useVoiceRecorder internally auto-stops at 60s, its status becomes
+  // "completed" but the flow's own flowStatus stays "recording". This effect
+  // bridges the gap so the overlay UI transitions to the completed state.
+  useEffect(() => {
+    if (
+      recorder.status === "completed" &&
+      flowStatusRef.current === "recording"
+    ) {
+      updateFlowStatus("completed");
+    }
+  }, [recorder.status, updateFlowStatus]);
+
+  // ---------------------------------------------------------------------------
   // Actions
   // ---------------------------------------------------------------------------
 
@@ -158,12 +173,22 @@ export function useVoiceTransactionFlow(
       return;
     }
 
-    // Stop recording
-    const result = await recorder.stop();
-    if (!result) {
-      setErrorMessage("Failed to finalize recording. Please try again.");
-      updateFlowStatus("error");
-      return;
+    // Resolve audio URI — either from an already-completed auto-stop (FR-004)
+    // or by explicitly stopping the recorder now.
+    let audioUri: string;
+
+    if (recorder.status === "completed" && recorder.audioUri) {
+      // Recorder already auto-stopped at 60s — use the finalized URI directly
+      audioUri = recorder.audioUri;
+    } else {
+      // Normal path: stop recording and get the finalized URI
+      const result = await recorder.stop();
+      if (!result) {
+        setErrorMessage("Failed to finalize recording. Please try again.");
+        updateFlowStatus("error");
+        return;
+      }
+      audioUri = result.uri;
     }
 
     // Show analyzing state
@@ -171,7 +196,7 @@ export function useVoiceTransactionFlow(
 
     // Submit to AI
     const aiResult = await parseVoiceWithAi({
-      audioUri: result.uri,
+      audioUri,
       preferredCurrency: config.preferredCurrency,
       categories: config.categories,
       accounts: config.accounts,


### PR DESCRIPTION
Fixes #165

## Description
Fixes an issue where voice recordings fail to auto-stop from the user's perspective at the 60-second limit, which previously caused errors like `Failed to finalize recording`.

The actual `useVoiceRecorder` hook auto-stops correctly under the hood at 60 seconds (setting `recorder.status` to `completed`), but `useVoiceTransactionFlow` maintained its own separate `flowStatus` state that never successfully synced to `completed`. This caused the overlay UI to stay stuck displaying "Recording...".

## Changes
- Added a `useEffect` observer in `useVoiceTransactionFlow` to transition `flowStatus` to `"completed"` as soon as the underlying recorder stops at the threshold.
- Refactored `submitRecording()` to safely consume the auto-stopped `recorder.audioUri` instead of invoking `recorder.stop()` twice under normal vs auto-stopped flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voice recording completion status is now properly synchronized throughout the recording lifecycle for accurate state management.
  * Audio file retrieval has been enhanced to reliably capture and submit voice recordings, working correctly whether the recording auto-completes or is manually stopped.
  * Recording submission now handles all recording completion scenarios more reliably and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->