### PR TITLE
fix: resolve i18n type safety, polling, and build issues

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -27,7 +27,6 @@ import { LocaleProvider } from "../context/LocaleContext";
 import i18n, { initI18n } from "../i18n";
 
 import "../global.css";
-import type { i18n as I18nInstance } from "i18next";
 
 import { ToastProvider } from "../components/ui/Toast";
 import { InitialSyncOverlay } from "../components/ui/InitialSyncOverlay";
@@ -147,7 +146,7 @@ export default function RootLayout(): React.ReactNode {
 
   return (
     <ErrorBoundary>
-      <I18nextProvider i18n={i18n as unknown as I18nInstance}>
+      <I18nextProvider i18n={i18n}>
         <GestureHandlerRootView className="flex-1">
           <QueryProvider>
             <DatabaseProvider>

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -342,14 +342,14 @@ export default function SettingsScreen(): React.JSX.Element {
           </TouchableOpacity>
         </View>
 
-        {/* {t("sms_sync")} Section (Android only) */}
+        {/* SMS Sync Section (Android only) */}
         {isAndroid && (
           <View className="mb-8">
             <Text className="text-[13px] font-semibold mb-3 ms-1 uppercase text-slate-500 dark:text-slate-400">
               {t("sms_sync")}
             </Text>
 
-            {/* {t("sync_new")} (incremental) */}
+            {/* Sync New Messages (incremental) */}
             <TouchableOpacity
               onPress={() => {
                 handleIncrementalSync().catch(() => {});

--- a/apps/mobile/constants/storage-keys.ts
+++ b/apps/mobile/constants/storage-keys.ts
@@ -30,5 +30,5 @@ export const LOGOUT_IN_PROGRESS_KEY = "@astik/logout-in-progress";
  */
 export const CLEARABLE_USER_KEYS: readonly string[] = [
   FIRST_USE_DATE_KEY,
-  LANGUAGE_KEY,
+  // LANGUAGE_KEY intentionally excluded — language preference persists across accounts
 ] as const;

--- a/apps/mobile/constants/typography.ts
+++ b/apps/mobile/constants/typography.ts
@@ -29,6 +29,16 @@ export const arabicFontFamily = {
 } as const;
 
 /**
+ * Shared font family shape for locale-specific font selection.
+ */
+export interface FontFamily {
+  readonly regular: string;
+  readonly medium: string;
+  readonly semiBold: string;
+  readonly bold: string;
+}
+
+/**
  * Get locale-appropriate font family based on current RTL state.
  *
  * This function automatically returns the correct font family (Inter for LTR,
@@ -36,7 +46,7 @@ export const arabicFontFamily = {
  *
  * @returns Font family object for the current locale
  */
-export function getLocaleFontFamily(): Readonly<typeof fontFamily> {
+export function getLocaleFontFamily(): FontFamily {
   return I18nManager.isRTL ? arabicFontFamily : fontFamily;
 }
 

--- a/apps/mobile/context/LocaleContext.tsx
+++ b/apps/mobile/context/LocaleContext.tsx
@@ -3,10 +3,9 @@ import { I18nManager } from "react-native";
 import i18n from "../i18n";
 import { getLocaleFontFamily } from "../constants/typography";
 
-/**
- * Supported languages in the app
- */
-export type SupportedLanguage = "en" | "ar";
+export type { SupportedLanguage } from "../i18n/translation-schema";
+
+import type { SupportedLanguage } from "../i18n/translation-schema";
 
 /**
  * Locale context state
@@ -31,8 +30,7 @@ const LocaleContext = createContext<LocaleContextType | undefined>(undefined);
  * Helper to get current language from i18n instance
  */
 function getCurrentI18nLanguage(): SupportedLanguage {
-  const instance = i18n as unknown as { language: string };
-  const lang = instance.language;
+  const lang = i18n.language;
   return lang === "ar" ? "ar" : "en";
 }
 
@@ -50,16 +48,16 @@ export const LocaleProvider: React.FC<{ children: React.ReactNode }> = ({
     getCurrentI18nLanguage()
   );
 
-  // Listen for language changes
+  // Listen for language changes via i18next's built-in event
   useEffect(() => {
-    const handleLanguageChange = (): void => {
-      setCurrentLanguage(getCurrentI18nLanguage());
+    const handleLanguageChange = (lng: string): void => {
+      setCurrentLanguage(lng === "ar" ? "ar" : "en");
     };
 
-    // i18next doesn't have a built-in event for language changes,
-    // so we use a polling approach or manual updates
-    const interval = setInterval(handleLanguageChange, 1000);
-    return () => clearInterval(interval);
+    i18n.on("languageChanged", handleLanguageChange);
+    return () => {
+      i18n.off("languageChanged", handleLanguageChange);
+    };
   }, []);
 
   const value = useMemo<LocaleContextType>(

--- a/apps/mobile/i18n/changeLanguage.ts
+++ b/apps/mobile/i18n/changeLanguage.ts
@@ -1,27 +1,11 @@
-import type { TFunction } from "i18next";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import i18n from "./index";
 
 import { LANGUAGE_KEY } from "@/constants/storage-keys";
 import { applyRTL } from "@/utils/rtl";
 
-/**
- * Supported languages in the app.
- */
-export type SupportedLanguage = "en" | "ar";
-
-/**
- * Get the i18n instance with proper typing
- */
-function getI18n(): {
-  language: string;
-  changeLanguage: (lang: string) => Promise<TFunction>;
-} {
-  return i18n as unknown as {
-    language: string;
-    changeLanguage: (lang: string) => Promise<TFunction>;
-  };
-}
+export type { SupportedLanguage } from "./translation-schema";
+import type { SupportedLanguage } from "./translation-schema";
 
 /**
  * Change the app language and apply RTL if needed.
@@ -41,8 +25,7 @@ export async function changeLanguage(lang: SupportedLanguage): Promise<void> {
   await AsyncStorage.setItem(LANGUAGE_KEY, lang);
 
   // Update i18next language
-  const instance = getI18n();
-  await instance.changeLanguage(lang);
+  await i18n.changeLanguage(lang);
 
   // Apply RTL layout (will trigger reload if changing to/from Arabic)
   await applyRTL(lang === "ar");
@@ -54,8 +37,7 @@ export async function changeLanguage(lang: SupportedLanguage): Promise<void> {
  * @returns Current language code ("en" or "ar")
  */
 export function getCurrentLanguage(): SupportedLanguage {
-  const instance = getI18n();
-  return instance.language === "ar" ? "ar" : "en";
+  return i18n.language === "ar" ? "ar" : "en";
 }
 
 /**

--- a/apps/mobile/i18n/index.ts
+++ b/apps/mobile/i18n/index.ts
@@ -75,8 +75,9 @@ async function detectInitialLanguage(): Promise<"en" | "ar"> {
     if (stored === "en" || stored === "ar") {
       return stored;
     }
-  } catch (error) {
-    console.warn("Failed to read language from AsyncStorage:", error);
+  } catch {
+    // TODO: Replace with structured logging (e.g., Sentry)
+    // Silently fall through to device locale detection
   }
 
   // Fallback to device locale
@@ -108,7 +109,7 @@ export async function initI18n(): Promise<void> {
 }
 
 /**
- * Export i18n instance for direct access if needed.
+ * Export i18next instance for direct access (e.g., language change, event listeners).
  * Most components should use useTranslation() hook instead.
  */
-export { default } from "react-i18next";
+export default i18next;

--- a/apps/mobile/utils/dateHelpers.ts
+++ b/apps/mobile/utils/dateHelpers.ts
@@ -5,9 +5,7 @@ import i18n from "../i18n";
  * Returns 'en' or 'ar' with proper type safety.
  */
 function getCurrentLanguage(): "en" | "ar" {
-  const instance = i18n as unknown as { language: string };
-  const lang = instance.language;
-  return lang === "ar" ? "ar" : "en";
+  return i18n.language === "ar" ? "ar" : "en";
 }
 
 const SHORT_MONTHS_EN = [
@@ -50,22 +48,8 @@ const DAYS_EN = [
   "Saturday",
 ];
 
-const SHORT_MONTHS_AR = [
-  "يناير",
-  "فبراير",
-  "مارس",
-  "أبريل",
-  "مايو",
-  "يونيو",
-  "يوليو",
-  "أغسطس",
-  "سبتمبر",
-  "أكتوبر",
-  "نوفمبر",
-  "ديسمبر",
-];
-
-const FULL_MONTHS_AR = [
+// Arabic month names (same for short and full — Arabic doesn't abbreviate month names)
+const MONTHS_AR = [
   "يناير",
   "فبراير",
   "مارس",
@@ -92,11 +76,11 @@ const DAYS_AR = [
 
 // Get localized month and day names based on current language
 function getShortMonths(): string[] {
-  return getCurrentLanguage() === "ar" ? SHORT_MONTHS_AR : SHORT_MONTHS_EN;
+  return getCurrentLanguage() === "ar" ? MONTHS_AR : SHORT_MONTHS_EN;
 }
 
 function getFullMonths(): string[] {
-  return getCurrentLanguage() === "ar" ? FULL_MONTHS_AR : FULL_MONTHS_EN;
+  return getCurrentLanguage() === "ar" ? MONTHS_AR : FULL_MONTHS_EN;
 }
 
 function getDays(): string[] {


### PR DESCRIPTION
## Summary

Fixes code quality issues identified in PR #174 code review.

- **Fix TS2322 build error**: Add shared `FontFamily` interface so `getLocaleFontFamily()` return type is compatible with both `fontFamily` and `arabicFontFamily`
- **Fix incorrect i18n export**: `i18n/index.ts` was exporting `react-i18next` module instead of `i18next` instance, causing all consumers to need unsafe `as unknown as` double casts
- **Remove 4 unsafe double casts**: `LocaleContext.tsx`, `changeLanguage.ts`, `dateHelpers.ts`, `_layout.tsx`
- **Replace polling with event listener**: `LocaleContext.tsx` used `setInterval(1000)` — replaced with i18next's built-in `languageChanged` event
- **Deduplicate `SupportedLanguage` type**: Was defined in 3 files, now single source in `translation-schema.ts`
- **Fix logout stale state**: Remove `LANGUAGE_KEY` from `CLEARABLE_USER_KEYS` — language pref should persist across accounts
- **Deduplicate Arabic month arrays**: `SHORT_MONTHS_AR` and `FULL_MONTHS_AR` were identical
- **Fix code comments**: Comments in `settings.tsx` incorrectly used `t()` calls
- **Remove `console.warn` in production**: Replaced with silent fallthrough + TODO

## Checklist

- [x] TS2322 build error resolved
- [x] All `as unknown as` casts removed
- [x] Polling replaced with event-driven approach
- [x] DRY violations fixed
- [x] Production logging removed
- [x] Lint passes

## Deferred (scope of PR #174, not this fix)

- 16 screen migrations still needed (auth, budgets, charts, live-rates, sms-scan, sms-review, etc.)
- Accessibility attributes (FR-016)
- Onboarding slides still use hardcoded English

## Test plan

- [ ] Verify app boots correctly with i18n initialized
- [ ] Verify language switch in Settings works
- [ ] Verify LocaleContext updates when language changes (no polling delay)
- [ ] Verify TypeScript builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)