### PR TITLE
fix: light theme contrast issues across SMS scan and account selector (#97)

### DIFF
--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -45,7 +45,7 @@ export default function Index(): React.ReactNode {
 
   if (!isReady) {
     return (
-      <View className="flex-1 justify-center items-center bg-slate-900">
+      <View className="flex-1 justify-center items-center bg-slate-50 dark:bg-slate-900">
         <ActivityIndicator size="large" color={palette.nileGreen[500]} />
       </View>
     );

--- a/apps/mobile/app/sms-scan.tsx
+++ b/apps/mobile/app/sms-scan.tsx
@@ -142,7 +142,10 @@ export default function SmsScanScreen(): React.JSX.Element {
   );
 
   return (
-    <SafeAreaView className="flex-1 bg-slate-900" edges={["top", "bottom"]}>
+    <SafeAreaView
+      className="flex-1 bg-slate-50 dark:bg-slate-900"
+      edges={["top", "bottom"]}
+    >
       <SmsScanProgress
         status={status}
         progress={progress}

--- a/apps/mobile/components/sms-sync/SmsPermissionPrompt.tsx
+++ b/apps/mobile/components/sms-sync/SmsPermissionPrompt.tsx
@@ -67,7 +67,9 @@ function FeatureBullet({
         <Ionicons name={icon} size={20} color={palette.nileGreen[500]} />
       </View>
       <View className="flex-1">
-        <Text className="text-white font-semibold text-base">{title}</Text>
+        <Text className="text-slate-800 dark:text-white font-semibold text-base">
+          {title}
+        </Text>
         <Text className="text-slate-400 text-sm mt-0.5">{description}</Text>
       </View>
     </Animated.View>
@@ -104,7 +106,7 @@ export function SmsPermissionPrompt({
       <TouchableWithoutFeedback onPress={onDismiss}>
         <View className="flex-1 bg-black/60 justify-end">
           <TouchableWithoutFeedback>
-            <View className="bg-slate-900 rounded-t-3xl px-6 pt-8 pb-10">
+            <View className="bg-white dark:bg-slate-900 rounded-t-3xl px-6 pt-8 pb-10">
               {/* Header Icon */}
               <Animated.View
                 entering={FadeInUp.delay(200).springify()}
@@ -117,7 +119,7 @@ export function SmsPermissionPrompt({
                     color={palette.nileGreen[500]}
                   />
                 </View>
-                <Text className="text-white text-2xl font-bold text-center">
+                <Text className="text-slate-800 dark:text-white text-2xl font-bold text-center">
                   Auto-Track Transactions
                 </Text>
                 <Text className="text-slate-400 text-base text-center mt-2 px-4">

--- a/apps/mobile/components/sms-sync/SmsScanProgress.tsx
+++ b/apps/mobile/components/sms-sync/SmsScanProgress.tsx
@@ -21,6 +21,7 @@ import { ScrollView, Text, TouchableOpacity, View } from "react-native";
 import Animated, { FadeIn, FadeInDown, ZoomIn } from "react-native-reanimated";
 import Svg, { Circle } from "react-native-svg";
 import { useCategories } from "@/hooks/useCategories";
+import { useTheme } from "@/context/ThemeContext";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -75,7 +76,7 @@ export function SmsScanProgress({
   onRetryPress,
 }: SmsScanProgressProps): React.JSX.Element {
   return (
-    <View className="flex-1 bg-slate-900">
+    <View className="flex-1 bg-slate-50 dark:bg-slate-900">
       {/* ── Header ───────────────────────────────────────────── */}
       <View className="flex-row items-center px-4 pt-2 pb-3">
         <TouchableOpacity
@@ -86,7 +87,7 @@ export function SmsScanProgress({
         >
           <Ionicons name="chevron-back" size={24} color={palette.slate[400]} />
         </TouchableOpacity>
-        <Text className="flex-1 text-center text-base font-bold text-white -ms-10">
+        <Text className="flex-1 text-center text-base font-bold text-slate-800 dark:text-white -ms-10">
           SMS Scan
         </Text>
       </View>
@@ -133,9 +134,9 @@ export function SmsScanProgress({
           <TouchableOpacity
             onPress={onBackPress}
             activeOpacity={0.85}
-            className="w-full py-4 rounded-2xl bg-slate-800 items-center"
+            className="w-full py-4 rounded-2xl bg-slate-100 dark:bg-slate-800 items-center"
           >
-            <Text className="text-white text-sm font-semibold">
+            <Text className="text-slate-800 dark:text-white text-sm font-semibold">
               Cancel Scan
             </Text>
           </TouchableOpacity>
@@ -190,7 +191,7 @@ function CircularProgressRing({
       </Svg>
       {/* Center text overlay */}
       <View className="absolute items-center justify-center">
-        <Text className="text-3xl font-extrabold text-white">
+        <Text className="text-3xl font-extrabold text-slate-800 dark:text-white">
           {clampedPercentage}%
         </Text>
       </View>
@@ -260,10 +261,10 @@ function ScanningState({
   return (
     <Animated.View entering={FadeIn.duration(400)} className="flex-1">
       {/* ── Hero Card ───────────────────────────────────────── */}
-      <View className="bg-slate-800 rounded-3xl p-6 items-center mt-2">
+      <View className="bg-white dark:bg-slate-800 rounded-3xl p-6 items-center mt-2">
         <CircularProgressRing percentage={percentage} />
 
-        <Text className="text-lg font-semibold text-white mt-4">
+        <Text className="text-lg font-semibold text-slate-800 dark:text-white mt-4">
           {statusText}
         </Text>
 
@@ -339,7 +340,7 @@ function ScanningState({
       </View>
 
       {/* ── Pipeline Status ─────────────────────────────────── */}
-      <View className="bg-slate-800 rounded-3xl p-5 mt-3">
+      <View className="bg-white dark:bg-slate-800 rounded-3xl p-5 mt-3">
         <Text className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">
           Pipeline Status
         </Text>
@@ -472,7 +473,7 @@ function SuccessState({
           </View>
         </View>
 
-        <Text className="text-2xl font-bold text-white mt-5">
+        <Text className="text-2xl font-bold text-slate-800 dark:text-white mt-5">
           Scan Complete!
         </Text>
         <Text className="text-sm text-slate-400 mt-1">
@@ -481,7 +482,7 @@ function SuccessState({
       </View>
 
       {/* ── Summary Card ────────────────────────────────────── */}
-      <View className="bg-slate-800 rounded-3xl mt-6">
+      <View className="bg-white dark:bg-slate-800 rounded-3xl mt-6">
         <SummaryRow
           label="Messages Scanned"
           value={totalScanned.toLocaleString()}
@@ -562,11 +563,11 @@ function EmptyState({
       entering={FadeInDown.springify()}
       className="flex-1 items-center justify-center"
     >
-      <View className="w-20 h-20 rounded-full bg-slate-800 items-center justify-center mb-6">
+      <View className="w-20 h-20 rounded-full bg-slate-100 dark:bg-slate-800 items-center justify-center mb-6">
         <Ionicons name="search-outline" size={40} color={palette.slate[400]} />
       </View>
 
-      <Text className="text-xl font-bold text-white mb-2">
+      <Text className="text-xl font-bold text-slate-800 dark:text-white mb-2">
         No Transactions Found
       </Text>
       <Text className="text-sm text-slate-400 text-center mb-4">
@@ -574,7 +575,7 @@ function EmptyState({
       </Text>
 
       {/* ── Reasons Card ────────────────────────────────────── */}
-      <View className="bg-slate-800 rounded-2xl p-4 w-full mb-8">
+      <View className="bg-white dark:bg-slate-800 rounded-2xl p-4 w-full mb-8">
         <Text className="text-sm font-semibold text-slate-300 mb-3">
           Possible Reasons
         </Text>
@@ -587,7 +588,7 @@ function EmptyState({
         <TouchableOpacity
           onPress={onBackPress}
           activeOpacity={0.85}
-          className="w-full py-4 rounded-2xl bg-slate-800 items-center"
+          className="w-full py-4 rounded-2xl bg-slate-100 dark:bg-slate-800 items-center"
         >
           <Text className="text-slate-300 text-sm font-semibold">
             Back to Dashboard
@@ -625,10 +626,12 @@ function ErrorState({
         <Ionicons name="warning-outline" size={36} color={palette.red[500]} />
       </View>
 
-      <Text className="text-xl font-bold text-white mb-2">Scan Failed</Text>
+      <Text className="text-xl font-bold text-slate-800 dark:text-white mb-2">
+        Scan Failed
+      </Text>
 
       {/* Error detail card */}
-      <View className="bg-slate-800 rounded-2xl p-4 w-full mb-4">
+      <View className="bg-white dark:bg-slate-800 rounded-2xl p-4 w-full mb-4">
         <View className="flex-row items-start">
           <View
             className="w-2 h-2 rounded-full mt-1.5 me-2"
@@ -661,7 +664,7 @@ function ErrorState({
         <TouchableOpacity
           onPress={onBackPress}
           activeOpacity={0.85}
-          className="w-full py-4 rounded-2xl bg-slate-800 items-center"
+          className="w-full py-4 rounded-2xl bg-slate-100 dark:bg-slate-800 items-center"
         >
           <Text className="text-slate-300 text-sm font-semibold">
             Back to Dashboard
@@ -692,8 +695,10 @@ function StatCard({
   readonly sublabel: string;
   readonly valueColor?: string;
 }): React.JSX.Element {
+  const { isDark } = useTheme();
+  const defaultValueColor = isDark ? palette.slate[25] : palette.slate[800];
   return (
-    <View className="flex-1 bg-slate-800 rounded-3xl p-4">
+    <View className="flex-1 bg-white dark:bg-slate-800 rounded-3xl p-4 border border-slate-200 dark:border-transparent">
       <View
         className="w-10 h-10 rounded-xl items-center justify-center mb-3"
         // eslint-disable-next-line react-native/no-inline-styles
@@ -707,7 +712,7 @@ function StatCard({
       <Text
         className="text-2xl font-bold"
         // eslint-disable-next-line react-native/no-inline-styles
-        style={{ color: valueColor ?? "#FFFFFF" }}
+        style={{ color: valueColor ?? defaultValueColor }}
       >
         {value.toLocaleString()}
         {total !== undefined && (
@@ -744,7 +749,8 @@ function PipelineStep({
       ? palette.nileGreen[400]
       : palette.slate[500];
 
-  const textColor = status === "pending" ? "text-slate-500" : "text-white";
+  const textColor =
+    status === "pending" ? "text-slate-500" : "text-slate-800 dark:text-white";
 
   return (
     <View className="flex-row">
@@ -826,17 +832,19 @@ function SummaryRow({
   readonly valueColor?: string;
   readonly isLast?: boolean;
 }): React.JSX.Element {
+  const { isDark } = useTheme();
+  const defaultValueColor = isDark ? palette.slate[25] : palette.slate[800];
   return (
     <View
       className={`flex-row items-center justify-between px-5 py-4 ${
-        !isLast ? "border-b border-slate-700" : ""
+        !isLast ? "border-b border-slate-200 dark:border-slate-700" : ""
       }`}
     >
       <Text className="text-sm text-slate-400">{label}</Text>
       <Text
         className="text-base font-bold"
         // eslint-disable-next-line react-native/no-inline-styles
-        style={{ color: valueColor ?? "#FFFFFF" }}
+        style={{ color: valueColor ?? defaultValueColor }}
       >
         {value}
       </Text>
@@ -857,9 +865,11 @@ function CategoryChip({
   const icon = getCategoryIcon(name);
 
   return (
-    <View className="flex-row items-center bg-slate-800 rounded-xl px-3 py-2">
+    <View className="flex-row items-center bg-slate-100 dark:bg-slate-800 rounded-xl px-3 py-2">
       <Ionicons name={icon} size={14} color={palette.nileGreen[400]} />
-      <Text className="text-xs text-white ms-1.5">{displayName}</Text>
+      <Text className="text-xs text-slate-800 dark:text-white ms-1.5">
+        {displayName}
+      </Text>
     </View>
   );
 }

--- a/apps/mobile/components/transaction-review/edit-modal/AccountSelector.tsx
+++ b/apps/mobile/components/transaction-review/edit-modal/AccountSelector.tsx
@@ -114,7 +114,7 @@ export function AccountSelector({
       {/* Down arrow indicator for secondary field (ATM Cash) */}
       {isSecondary && (
         <View className="items-center -my-3 z-10 relative">
-          <View className="bg-slate-900 border border-slate-700/50 rounded-full w-8 h-8 items-center justify-center">
+          <View className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700/50 rounded-full w-8 h-8 items-center justify-center">
             <Ionicons name="arrow-down" size={16} color={palette.slate[400]} />
           </View>
         </View>
@@ -148,10 +148,10 @@ export function AccountSelector({
       {allowCreateNew && (isCreatingNew || !hasOptions) ? (
         <View>
           <View
-            className={`bg-slate-800/60 rounded-xl px-4 py-3 flex-row items-center border ${
+            className={`bg-slate-100 dark:bg-slate-800/60 rounded-xl px-4 py-3 flex-row items-center border ${
               isCreatingNew
                 ? themeClasses.borderCreating
-                : "border-slate-700/50"
+                : "border-slate-200 dark:border-slate-700/50"
             }`}
           >
             {iconName && (
@@ -168,7 +168,7 @@ export function AccountSelector({
             <TextInput
               value={newAccountName}
               onChangeText={onNewAccountNameChange}
-              className="text-white text-base font-semibold flex-1"
+              className="text-slate-800 dark:text-white text-base font-semibold flex-1"
               placeholderTextColor={palette.slate[600]}
               placeholder={isSecondary ? "Cash account name" : "Account name"}
               autoFocus={isCreatingNew}
@@ -201,8 +201,10 @@ export function AccountSelector({
           <TouchableOpacity
             onPress={onTogglePicker}
             activeOpacity={0.7}
-            className={`bg-slate-800/60 rounded-xl px-4 py-3 flex-row items-center justify-between border ${
-              errorMsg ? "border-red-500/60" : "border-slate-700/50"
+            className={`bg-slate-100 dark:bg-slate-800/60 rounded-xl px-4 py-3 flex-row items-center justify-between border ${
+              errorMsg
+                ? "border-red-500/60"
+                : "border-slate-200 dark:border-slate-700/50"
             }`}
           >
             <View className="flex-row items-center flex-1">
@@ -218,7 +220,7 @@ export function AccountSelector({
                 </View>
               )}
               <Text
-                className="text-base text-white font-semibold flex-1"
+                className="text-base text-slate-800 dark:text-white font-semibold flex-1"
                 numberOfLines={1}
               >
                 {selectedName || placeholder}
@@ -235,7 +237,7 @@ export function AccountSelector({
           )}
 
           {isPickerOpen && (
-            <View className="mt-2 bg-slate-800/80 rounded-xl overflow-hidden border border-slate-700/40">
+            <View className="mt-2 bg-white dark:bg-slate-800/80 rounded-xl overflow-hidden border border-slate-200 dark:border-slate-700/40">
               {/* Section headers + grouped accounts (when available) */}
               {showSectionHeaders &&
                 matchingAccounts &&
@@ -254,7 +256,7 @@ export function AccountSelector({
                     key={opt.id}
                     onPress={() => onSelect(opt)}
                     activeOpacity={0.7}
-                    className={`px-4 py-3 flex-row items-center justify-between border-b border-slate-700/30 ${
+                    className={`px-4 py-3 flex-row items-center justify-between border-b border-slate-200 dark:border-slate-700/30 ${
                       isSelected ? themeClasses.selectedRowBg : ""
                     }`}
                   >
@@ -274,7 +276,7 @@ export function AccountSelector({
                         className={`text-sm font-medium flex-shrink ${
                           isSelected
                             ? themeClasses.selectedRowText
-                            : "text-white"
+                            : "text-slate-800 dark:text-white"
                         }`}
                         numberOfLines={1}
                       >
@@ -308,7 +310,7 @@ export function AccountSelector({
                 otherAccounts &&
                 otherAccounts.length > 0 && (
                   <>
-                    <Text className="px-4 pt-3 pb-1 text-[10px] font-bold text-slate-500 uppercase tracking-wider border-t border-slate-700/40">
+                    <Text className="px-4 pt-3 pb-1 text-[10px] font-bold text-slate-500 uppercase tracking-wider border-t border-slate-200 dark:border-slate-700/40">
                       Other accounts
                     </Text>
                     {otherAccounts.map((opt) => {
@@ -318,7 +320,7 @@ export function AccountSelector({
                           key={opt.id}
                           onPress={() => onSelect(opt)}
                           activeOpacity={0.7}
-                          className={`px-4 py-3 flex-row items-center justify-between border-b border-slate-700/30 ${
+                          className={`px-4 py-3 flex-row items-center justify-between border-b border-slate-200 dark:border-slate-700/30 ${
                             isSelected ? themeClasses.selectedRowBg : ""
                           }`}
                         >
@@ -338,7 +340,7 @@ export function AccountSelector({
                               className={`text-sm font-medium flex-shrink ${
                                 isSelected
                                   ? themeClasses.selectedRowText
-                                  : "text-white"
+                                  : "text-slate-800 dark:text-white"
                               }`}
                               numberOfLines={1}
                             >
@@ -375,7 +377,7 @@ export function AccountSelector({
                 <TouchableOpacity
                   onPress={onStartNew}
                   activeOpacity={0.7}
-                  className="px-4 py-3 flex-row items-center border-t border-slate-700/40"
+                  className="px-4 py-3 flex-row items-center border-t border-slate-200 dark:border-slate-700/40"
                 >
                   <View
                     className={`w-5 h-5 rounded-full items-center justify-center me-2 ${themeClasses.pillBg}`}


### PR DESCRIPTION
## Summary

Fixes #97 — light theme had unreadable text, dark backgrounds bleeding into light mode, and invisible borders on several screens.

After auditing the full app, the theme system itself (`ThemeContext`, `tailwind.config.js`) and shared primitives (`PageHeader`, `Button`, `TextField`, `Dropdown`) were already correct. Bugs were localized to a handful of components authored dark-first that never got light-mode counterparts. Several other dark-styled components (Gold/Metal hero cards, `TotalNetWorthCard`, settings icon badges, primary CTA buttons) are **intentionally** dark per their JSDoc / mockup design and were left alone.

## Changes

- **`app/sms-scan.tsx`** — root `SafeAreaView` now `bg-slate-50 dark:bg-slate-900`.
- **`app/index.tsx`** — loading screen wrapper now light-mode aware.
- **`components/sms-sync/SmsScanProgress.tsx`** — full-screen wrapper, header title, hero/stat/pipeline/summary cards, all body text, dividers, category chips, and pipeline step labels gained light-mode variants. `StatCard`/`SummaryRow` value colors now read from `useTheme()` instead of hardcoded `#FFFFFF`.
- **`components/sms-sync/SmsPermissionPrompt.tsx`** — bottom sheet bg, title, and feature bullet titles now have light variants.
- **`components/transaction-review/edit-modal/AccountSelector.tsx`** — input/dropdown backgrounds, all borders, account name text, and the secondary-field arrow indicator now have light variants.

All fixes follow the project rules: NativeWind `dark:` variants (no `isDark` ternaries on classNames), `palette` from `@/constants/colors` for any non-className color, `palette.slate[25]` as the light-mode baseline.

## Test plan

- [ ] Toggle Settings → Appearance between Light / Dark / System
- [ ] SMS Scan flow (`/sms-scan`): scanning state, success state, empty state, error state — all readable in light mode
- [ ] SMS permission prompt — bottom sheet readable in light mode
- [ ] Initial loading screen (cold start) — light bg in light mode
- [ ] Transaction review edit modal → AccountSelector — both creating-new and dropdown modes legible in light mode
- [ ] Regression: dark mode unchanged on all the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)