### PR TITLE
feat: dev-only SMS simulator for live detection testing (#79)

### DIFF
--- a/apps/mobile/app/sms-simulator.tsx
+++ b/apps/mobile/app/sms-simulator.tsx
@@ -1,0 +1,237 @@
+/**
+ * Dev-only SMS Simulator screen.
+ *
+ * Injects fake SMS payloads into the live detection pipeline by re-emitting
+ * the same DeviceEventEmitter event the native SmsBroadcastReceiver emits.
+ * The full pipeline (filter → dedup → AI parse → account resolve → persist)
+ * runs unchanged, so this validates the live detection feature end-to-end
+ * without needing actual bank SMS messages.
+ *
+ * Guarded by `__DEV__` — renders nothing in release builds.
+ *
+ * @module sms-simulator
+ */
+
+import { PageHeader } from "@/components/navigation/PageHeader";
+import { palette } from "@/constants/colors";
+import {
+  injectBurst,
+  injectFakeSms,
+  injectFixture,
+  resetSimulatorState,
+} from "@/services/dev/sms-simulator";
+import { SMS_FIXTURES, type SmsFixture } from "@/services/dev/sms-fixtures";
+import { onTransactionDetected } from "@/services/sms-live-listener-service";
+import type { ParsedSmsTransaction } from "@astik/logic";
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  FlatList,
+  ScrollView,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+const MAX_LOG_ENTRIES = 10;
+const BURST_FIXTURE_ID = "nbe_debit_purchase";
+
+interface LogEntry {
+  readonly id: string;
+  readonly receivedAt: number;
+  readonly tx: ParsedSmsTransaction;
+}
+
+function FixtureRow({
+  fixture,
+  onInject,
+}: {
+  fixture: SmsFixture;
+  onInject: (id: string) => void;
+}): React.JSX.Element {
+  const handlePress = useCallback((): void => {
+    onInject(fixture.id);
+  }, [fixture.id, onInject]);
+
+  return (
+    <View className="mb-2 rounded-xl bg-slate-100 p-3 dark:bg-slate-800">
+      <Text className="text-sm font-semibold text-slate-900 dark:text-slate-50">
+        {fixture.label}
+      </Text>
+      <Text className="mt-0.5 text-xs text-slate-600 dark:text-slate-400">
+        {fixture.description}
+      </Text>
+      <Text
+        className="mt-1 text-xs text-slate-500 dark:text-slate-500"
+        numberOfLines={2}
+      >
+        {fixture.sender}: {fixture.body}
+      </Text>
+      <TouchableOpacity
+        onPress={handlePress}
+        className="mt-2 self-start rounded-lg bg-emerald-600 px-3 py-1.5 dark:bg-emerald-500"
+      >
+        <Text className="text-xs font-semibold text-white">Inject</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const SCROLL_CONTENT_STYLE = { padding: 16, paddingBottom: 32 } as const;
+
+export default function SmsSimulatorScreen(): React.JSX.Element | null {
+  const [log, setLog] = useState<readonly LogEntry[]>([]);
+  const [customSender, setCustomSender] = useState<string>("");
+  const [customBody, setCustomBody] = useState<string>("");
+
+  // Subscribe to detected transactions and append to live log
+  useEffect(() => {
+    const unsubscribe = onTransactionDetected(
+      (tx: ParsedSmsTransaction): void => {
+        setLog((prev) => {
+          const entry: LogEntry = {
+            id: `${tx.smsBodyHash}-${Date.now()}`,
+            receivedAt: Date.now(),
+            tx,
+          };
+          const next = [entry, ...prev];
+          return next.slice(0, MAX_LOG_ENTRIES);
+        });
+      }
+    );
+    return unsubscribe;
+  }, []);
+
+  const handleInjectFixture = useCallback((id: string): void => {
+    injectFixture(id);
+  }, []);
+
+  const handleInjectCustom = useCallback((): void => {
+    if (!customSender.trim() || !customBody.trim()) return;
+    injectFakeSms({ sender: customSender.trim(), body: customBody.trim() });
+  }, [customSender, customBody]);
+
+  const handleBurst = useCallback((): void => {
+    injectBurst(BURST_FIXTURE_ID, 3);
+  }, []);
+
+  const handleReset = useCallback((): void => {
+    resetSimulatorState();
+    setLog([]);
+  }, []);
+
+  if (!__DEV__) return null;
+
+  return (
+    <SafeAreaView
+      className="flex-1 bg-slate-50 dark:bg-slate-900"
+      edges={["bottom"]}
+    >
+      <PageHeader title="SMS Simulator (dev)" showBackButton />
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={SCROLL_CONTENT_STYLE}
+      >
+        {/* Fixtures */}
+        <Text className="mb-2 text-base font-bold text-slate-900 dark:text-slate-50">
+          Fixtures
+        </Text>
+        <FlatList
+          data={SMS_FIXTURES}
+          keyExtractor={(f) => f.id}
+          renderItem={({ item }) => (
+            <FixtureRow fixture={item} onInject={handleInjectFixture} />
+          )}
+          scrollEnabled={false}
+        />
+
+        {/* Free-form */}
+        <Text className="mb-2 mt-4 text-base font-bold text-slate-900 dark:text-slate-50">
+          Custom inject
+        </Text>
+        <TextInput
+          value={customSender}
+          onChangeText={setCustomSender}
+          placeholder="Sender (e.g. NBE)"
+          placeholderTextColor={palette.slate[400]}
+          className="mb-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-50"
+        />
+        <TextInput
+          value={customBody}
+          onChangeText={setCustomBody}
+          placeholder="SMS body…"
+          placeholderTextColor={palette.slate[400]}
+          multiline
+          numberOfLines={4}
+          className="mb-2 min-h-[80px] rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-50"
+          textAlignVertical="top"
+        />
+        <TouchableOpacity
+          onPress={handleInjectCustom}
+          className="self-start rounded-lg bg-emerald-600 px-4 py-2 dark:bg-emerald-500"
+        >
+          <Text className="text-sm font-semibold text-white">
+            Inject custom
+          </Text>
+        </TouchableOpacity>
+
+        {/* Tools */}
+        <Text className="mb-2 mt-6 text-base font-bold text-slate-900 dark:text-slate-50">
+          Tools
+        </Text>
+        <View className="flex-row gap-2">
+          <TouchableOpacity
+            onPress={handleBurst}
+            className="rounded-lg bg-amber-600 px-4 py-2 dark:bg-amber-500"
+          >
+            <Text className="text-sm font-semibold text-white">
+              Burst (×3) — dedup test
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={handleReset}
+            className="rounded-lg bg-rose-600 px-4 py-2 dark:bg-rose-500"
+          >
+            <Text className="text-sm font-semibold text-white">
+              Reset cache + log
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* Live log */}
+        <Text className="mb-2 mt-6 text-base font-bold text-slate-900 dark:text-slate-50">
+          Live detection log ({log.length}/{MAX_LOG_ENTRIES})
+        </Text>
+        {log.length === 0 ? (
+          <Text className="text-sm text-slate-500 dark:text-slate-400">
+            No transactions detected yet. Inject a fixture above.
+          </Text>
+        ) : (
+          log.map((entry) => (
+            <View
+              key={entry.id}
+              className="mb-2 rounded-xl bg-slate-100 p-3 dark:bg-slate-800"
+            >
+              <Text className="text-sm font-semibold text-slate-900 dark:text-slate-50">
+                {entry.tx.amount} {entry.tx.currency} ·{" "}
+                {entry.tx.categoryDisplayName ?? "(no category)"}
+              </Text>
+              <Text className="text-xs text-slate-600 dark:text-slate-400">
+                from {entry.tx.senderDisplayName}
+                {entry.tx.cardLast4 ? ` · card ****${entry.tx.cardLast4}` : ""}
+                {entry.tx.isAtmWithdrawal ? " · ATM" : ""}
+              </Text>
+              <Text
+                className="mt-1 text-xs text-slate-500 dark:text-slate-500"
+                numberOfLines={2}
+              >
+                {entry.tx.rawSmsBody}
+              </Text>
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/apps/mobile/services/dev/sms-fixtures.ts
+++ b/apps/mobile/services/dev/sms-fixtures.ts
@@ -1,0 +1,85 @@
+/**
+ * Dev-only SMS fixtures for the Live SMS Detection simulator.
+ *
+ * Each fixture is a realistic financial (or non-financial) SMS body used
+ * to drive the same `onSmsReceived` pipeline the native Android
+ * SmsBroadcastReceiver drives in production.
+ *
+ * Used exclusively by `apps/mobile/app/sms-simulator.tsx` and is guarded
+ * by `__DEV__` at the call sites so it is tree-shaken in release builds.
+ *
+ * @module services/dev/sms-fixtures
+ */
+
+export interface SmsFixture {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+  readonly sender: string;
+  readonly body: string;
+}
+
+export const SMS_FIXTURES: readonly SmsFixture[] = [
+  {
+    id: "nbe_debit_purchase",
+    label: "NBE — Debit purchase (EGP)",
+    description: "Standard NBE debit card purchase, happy path",
+    sender: "NBE",
+    body: "Purchase EGP 250.00 on card **** 4321 at CARREFOUR CAIRO on 08/04 14:23. Avail bal EGP 12,430.55",
+  },
+  {
+    id: "cib_credit_payment",
+    label: "CIB — Credit card payment",
+    description: "CIB credit card charge",
+    sender: "CIB",
+    body: "CIB: EGP 1,299.00 charged on your credit card ending 9988 at AMAZON.EG on 08-APR-2026. Bal: EGP 4,201.00",
+  },
+  {
+    id: "qnb_atm_withdrawal",
+    label: "QNB — ATM withdrawal",
+    description: "Exercises the ATM transfer branch in detection-handler",
+    sender: "QNB",
+    body: "QNB Alahli: ATM cash withdrawal EGP 2,000.00 from card **** 5566 on 08/04/2026 15:02. Avail bal EGP 8,000.00",
+  },
+  {
+    id: "nbe_transfer_in",
+    label: "NBE — Incoming transfer",
+    description: "Income path",
+    sender: "NBE",
+    body: "NBE: Credit EGP 15,000.00 to your account **** 4321 via transfer from MOHAMED SAMIR on 08/04. New bal EGP 27,430.55",
+  },
+  {
+    id: "usd_purchase",
+    label: "CIB — USD purchase",
+    description: "Multi-currency path",
+    sender: "CIB",
+    body: "CIB: USD 49.99 charged on your card **** 9988 at NETFLIX.COM on 08-APR-2026",
+  },
+  {
+    id: "card_last4_match",
+    label: "Card-last-4 matcher",
+    description:
+      "Forces the card-last-4 resolution branch in sms-account-matcher",
+    sender: "NBE",
+    body: "Purchase EGP 75.00 on card **** 1234 at STARBUCKS MAADI on 08/04 09:15. Avail bal EGP 5,200.00",
+  },
+  {
+    id: "non_financial_spam",
+    label: "Non-financial spam (should be filtered)",
+    description: "Expected to be dropped by isLikelyFinancialSms",
+    sender: "VODAFONE",
+    body: "Your Vodafone data bundle will expire in 2 days. Renew now by dialing *888#",
+  },
+  {
+    id: "duplicate_of_nbe_debit",
+    label: "Duplicate of NBE debit (dedup test)",
+    description:
+      "Identical body to nbe_debit_purchase; second inject should be deduped",
+    sender: "NBE",
+    body: "Purchase EGP 250.00 on card **** 4321 at CARREFOUR CAIRO on 08/04 14:23. Avail bal EGP 12,430.55",
+  },
+];
+
+export function getFixtureById(id: string): SmsFixture | null {
+  return SMS_FIXTURES.find((f) => f.id === id) ?? null;
+}

--- a/apps/mobile/services/dev/sms-simulator.ts
+++ b/apps/mobile/services/dev/sms-simulator.ts
@@ -1,0 +1,80 @@
+/**
+ * Dev-only SMS simulator.
+ *
+ * Re-emits the same `onSmsReceived` DeviceEventEmitter event the native
+ * SmsBroadcastReceiver emits in production. Because the live listener
+ * subscribes to that exact event name (see `sms-live-listener-service.ts`),
+ * the entire pipeline (keyword filter → hash dedup → AI parse → account
+ * resolve → persist) runs unchanged from a fake injection.
+ *
+ * All entry points are guarded by `__DEV__` so the module is tree-shaken
+ * in release builds.
+ *
+ * @module services/dev/sms-simulator
+ */
+
+import { DeviceEventEmitter } from "react-native";
+import { clearRecentHashes as clearLiveListenerHashes } from "../sms-live-listener-service";
+import { getFixtureById, type SmsFixture } from "./sms-fixtures";
+
+/** Must match `NATIVE_SMS_EVENT` in sms-live-listener-service.ts */
+const NATIVE_SMS_EVENT = "onSmsReceived";
+
+interface InjectArgs {
+  readonly sender: string;
+  readonly body: string;
+  readonly timestamp?: number;
+}
+
+/**
+ * Inject a fake SMS into the live detection pipeline.
+ * No-op outside dev builds.
+ */
+export function injectFakeSms({ sender, body, timestamp }: InjectArgs): void {
+  if (!__DEV__) return;
+
+  DeviceEventEmitter.emit(NATIVE_SMS_EVENT, {
+    sender,
+    body,
+    timestamp: timestamp ?? Date.now(),
+  });
+}
+
+/**
+ * Inject a named fixture by id. Returns the fixture that was injected, or
+ * `null` if no fixture was found (or in non-dev builds).
+ */
+export function injectFixture(fixtureId: string): SmsFixture | null {
+  if (!__DEV__) return null;
+
+  const fixture = getFixtureById(fixtureId);
+  if (!fixture) return null;
+
+  injectFakeSms({ sender: fixture.sender, body: fixture.body });
+  return fixture;
+}
+
+/**
+ * Inject the same fixture multiple times in rapid succession to verify the
+ * dedup cache (`recentHashes` in sms-live-listener-service).
+ */
+export function injectBurst(fixtureId: string, count: number = 3): number {
+  if (!__DEV__) return 0;
+
+  const fixture = getFixtureById(fixtureId);
+  if (!fixture) return 0;
+
+  for (let i = 0; i < count; i++) {
+    injectFakeSms({ sender: fixture.sender, body: fixture.body });
+  }
+  return count;
+}
+
+/**
+ * Reset the live listener's in-memory dedup cache so previously-injected
+ * fixtures can be re-processed.
+ */
+export function resetSimulatorState(): void {
+  if (!__DEV__) return;
+  clearLiveListenerHashes();
+}


### PR DESCRIPTION
## Summary
- Adds a dev-only SMS simulator that injects fake payloads into the live detection pipeline by re-emitting the same `onSmsReceived` `DeviceEventEmitter` event the native `SmsBroadcastReceiver` emits — so keyword filter → hash dedup → AI parse → account resolver → persistence all run unchanged.
- New fixture set covers happy paths (NBE/CIB debit & credit), ATM withdrawal, multi-currency, card-last-4 matcher, spam filter, and a duplicate for dedup verification.
- New dev screen at `/sms-simulator` with fixture list, custom inject, burst (×3) dedup test, cache reset, and a live detection log subscribed via `onTransactionDetected`.
- All entry points guarded by `__DEV__` so the module is tree-shaken in release builds. No refactor to the live listener was required.

Closes #79

## Test plan
- [ ] Launch on Android with SMS permission; open `/sms-simulator`
- [ ] Inject `nbe_debit_purchase` → transaction appears in log and in transactions list with `source: "SMS"`
- [ ] Burst test → only one transaction persisted; console shows "Duplicate SMS detected"
- [ ] Inject `non_financial_spam` → filtered out, no log entry
- [ ] Inject `card_last4_match` → resolver picks the matching account
- [ ] Inject `qnb_atm_withdrawal` → ATM transfer branch executes
- [ ] Reset cache → previously deduped fixture is accepted again
- [ ] Release build: verify `/sms-simulator` screen and the dev service are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added development-only SMS simulator screen with testing utilities
  * Included pre-configured SMS test fixtures for common financial scenarios (purchases, transfers, withdrawals)
  * Implemented tools to inject custom messages, perform batch testing, and reset simulator state
  * Added live transaction detection log for monitoring and verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->