### PR TITLE
refactor: replace native Alert.alert with custom ConfirmationModal and Toast

### DIFF
--- a/apps/mobile/app/onboarding.tsx
+++ b/apps/mobile/app/onboarding.tsx
@@ -38,7 +38,6 @@ import React, {
   useState,
 } from "react";
 import {
-  Alert,
   Dimensions,
   StyleSheet,
   Text,
@@ -48,6 +47,7 @@ import {
 import Carousel, { ICarouselInstance } from "react-native-reanimated-carousel";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { useToast } from "@/components/ui/Toast";
 import { CurrencyPickerStep } from "@/components/onboarding/CurrencyPickerStep";
 import { LanguagePickerStep } from "@/components/onboarding/LanguagePickerStep";
 import { WalletCreationStep } from "@/components/onboarding/WalletCreationStep";
@@ -139,6 +139,7 @@ export default function OnboardingScreen(): React.JSX.Element | null {
   );
   const [userId, setUserId] = useState<string | null>(null);
   const { isLoading: isAuthLoading } = useAuth();
+  const { showToast } = useToast();
 
   /**
    * Navigate to the main app after onboarding.
@@ -244,16 +245,16 @@ export default function OnboardingScreen(): React.JSX.Element | null {
       } catch (error) {
         // TODO: Replace with structured logging (e.g., Sentry)
         console.error("Failed to change language:", error);
-        Alert.alert(
-          tCommon("error"),
-          tCommon("language_change_failed"),
-          [{ text: tCommon("ok") }]
-        );
+        showToast({
+          type: "error",
+          title: tCommon("error"),
+          message: tCommon("language_change_failed"),
+        });
       } finally {
         setIsChangingLanguage(false);
       }
     },
-    [isChangingLanguage, tCommon]
+    [isChangingLanguage, tCommon, showToast]
   );
 
   const handleNext = useCallback((): void => {

--- a/apps/mobile/app/sms-review.tsx
+++ b/apps/mobile/app/sms-review.tsx
@@ -17,6 +17,7 @@
  * @module sms-review
  */
 
+import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 import { TransactionReview } from "@/components/transaction-review/TransactionReview";
 import { useToast } from "@/components/ui/Toast";
 import { palette } from "@/constants/colors";
@@ -32,7 +33,7 @@ import type { ReviewableTransaction } from "@astik/logic";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import React, { useCallback, useEffect, useState } from "react";
-import { Alert, Text, TouchableOpacity } from "react-native";
+import { Text, TouchableOpacity } from "react-native";
 import { useTranslation } from "react-i18next";
 import { SafeAreaView } from "react-native-safe-area-context";
 
@@ -48,6 +49,7 @@ export default function SmsReviewScreen(): React.JSX.Element {
   const { showToast } = useToast();
 
   const [isSaving, setIsSaving] = useState(false);
+  const [discardConfirmVisible, setDiscardConfirmVisible] = useState(false);
 
   // Mark review as active to queue incoming live transactions
   useEffect(() => {
@@ -117,18 +119,13 @@ export default function SmsReviewScreen(): React.JSX.Element {
   // ── Discard ─────────────────────────────────────────────────────────
 
   const handleDiscard = useCallback(() => {
-    Alert.alert(t("discard_all"), t("discard_all_confirm"), [
-      { text: t("cancel"), style: "cancel" },
-      {
-        text: t("discard"),
-        style: "destructive",
-        onPress: () => {
-          clearTransactions();
-          router.replace("/(tabs)");
-        },
-      },
-    ]);
-  }, [clearTransactions, router, t]);
+    setDiscardConfirmVisible(true);
+  }, []);
+
+  const handleConfirmDiscard = useCallback(() => {
+    clearTransactions();
+    router.replace("/(tabs)");
+  }, [clearTransactions, router]);
 
   // ── No transactions guard ───────────────────────────────────────────
 
@@ -172,6 +169,18 @@ export default function SmsReviewScreen(): React.JSX.Element {
         onSave={handleSave}
         onDiscard={handleDiscard}
         isSaving={isSaving}
+      />
+
+      {/* Discard confirmation */}
+      <ConfirmationModal
+        visible={discardConfirmVisible}
+        variant="danger"
+        title={t("discard_all")}
+        message={t("discard_all_confirm")}
+        confirmLabel={t("discard")}
+        cancelLabel={t("cancel")}
+        onConfirm={handleConfirmDiscard}
+        onCancel={() => setDiscardConfirmVisible(false)}
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary

Replace the last two `Alert.alert()` call sites with the app's existing custom UI components to ensure visual consistency across dark mode, RTL layouts, and i18n.

**Changes:**

- **`sms-review.tsx`** — Replaced destructive discard confirmation (`Alert.alert` with Cancel/Discard buttons) with `ConfirmationModal` (`variant="danger"`), reusing existing i18n keys (`discard_all`, `discard_all_confirm`, `discard`, `cancel`).
- **`onboarding.tsx`** — Replaced one-shot error notice (`Alert.alert` for language change failure) with `showToast({ type: "error" })`, matching the error handling pattern already used in `sms-review.tsx`.

**Why:**
- Native `Alert.alert` ignores the app's custom styling, dark mode palette, and RTL layout direction.
- The app already has `ConfirmationModal` (used in 9+ places) for two-button confirmations and `Toast` for non-blocking notices — these are the right primitives.

## Plan reference

Full plan: `C:\Users\Mohamed\.claude\plans\zippy-floating-globe.md`

## Test plan

- [ ] Type-check passes (`npx tsc -p apps/mobile/tsconfig.json --noEmit`)
- [ ] Grep confirms zero `Alert.alert` in `apps/mobile` app code
- [ ] SMS review discard flow: tap discard → custom danger modal appears → Cancel dismisses / Discard clears and navigates
- [ ] Onboarding language error: trigger a language change failure → red error toast appears (no native dialog)
- [ ] Verify both flows in light + dark mode, EN + AR locales
- [ ] Regression: existing `ConfirmationModal` consumers (voice-review, settings) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)