### PR TITLE
fix: scope onboarding guide steps per-user (cash account + SMS import)

### DIFF
--- a/apps/mobile/hooks/useOnboardingGuide.ts
+++ b/apps/mobile/hooks/useOnboardingGuide.ts
@@ -10,11 +10,13 @@
  * is set to `true` in WatermelonDB (syncs to Supabase).
  *
  * Steps:
- * 1. Cash account created (always true — auto-created during onboarding)
+ * 1. Cash account created (any account with type "CASH" exists for the user)
  * 2. Bank account added (any account with type "BANK" exists)
  * 3. First transaction recorded (any non-deleted transaction exists)
  * 4. Spending budget set (any active budget exists)
- * 5. SMS auto-import enabled (SMS permission granted + has synced)
+ * 5. SMS auto-import enabled (at least one transaction imported from SMS —
+ *    detected via `sms_body_hash` on any transaction; scoped per-user since
+ *    WatermelonDB is wiped on logout)
  *
  * @module useOnboardingGuide
  */
@@ -22,7 +24,6 @@
 import { logger } from "@/utils/logger";
 import { Account, Budget, Profile, Transaction, database } from "@rizqi/db";
 import { Q } from "@nozbe/watermelondb";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Platform } from "react-native";
 
@@ -74,24 +75,24 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
   const [setupGuideCompleted, setSetupGuideCompleted] = useState<
     boolean | null
   >(null);
+  const [hasCashAccount, setHasCashAccount] = useState(false);
   const [hasBankAccount, setHasBankAccount] = useState(false);
   const [hasTransaction, setHasTransaction] = useState(false);
   const [hasBudget, setHasBudget] = useState(false);
-  const [hasSmsEnabled, setHasSmsEnabled] = useState(false);
-  // NOTE: isLoading tracks the async SMS check + profile observation.
-  // WatermelonDB observers for bank/transaction/budget emit synchronously
-  // on subscribe, so those states are immediately available.
+  const [hasSmsImported, setHasSmsImported] = useState(false);
+  // NOTE: isLoading tracks the profile observation. WatermelonDB observers
+  // for accounts/transactions/budgets emit synchronously on subscribe, so
+  // those states are immediately available.
   const [isLoading, setIsLoading] = useState(true);
 
-  // Track loading for profile and SMS separately, mark done when both complete
+  // Track loading for profile; mark done when it emits.
   const [profileLoaded, setProfileLoaded] = useState(false);
-  const [smsLoaded, setSmsLoaded] = useState(false);
 
   useEffect(() => {
-    if (profileLoaded && smsLoaded) {
+    if (profileLoaded) {
       setIsLoading(false);
     }
-  }, [profileLoaded, smsLoaded]);
+  }, [profileLoaded]);
 
   // ── Observe profile for setupGuideCompleted ──
   // Use observeWithColumns to react to field-level changes (not just add/remove)
@@ -122,6 +123,24 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
   // Defaults to `true` (hidden) when the profile hasn't loaded yet to avoid
   // a flash of the card before we know the real state.
   const isDismissed = setupGuideCompleted ?? true;
+
+  // ── Observe cash accounts (type = "CASH") ──
+  useEffect(() => {
+    const subscription = database
+      .get<Account>("accounts")
+      .query(Q.where("deleted", false), Q.where("type", "CASH"))
+      .observeCount()
+      .subscribe({
+        next: (count) => {
+          setHasCashAccount(count > 0);
+        },
+        error: (error: unknown) => {
+          logger.error("Failed to observe cash accounts", error);
+        },
+      });
+
+    return () => subscription.unsubscribe();
+  }, []);
 
   // ── Observe bank accounts (type = "BANK") ──
   useEffect(() => {
@@ -177,29 +196,33 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
     return () => subscription.unsubscribe();
   }, []);
 
-  // ── Check SMS sync state ──
+  // ── Observe SMS-imported transactions (per-user via WatermelonDB) ──
+  // We look for any transaction with a non-null `sms_body_hash`, which is
+  // set only by the SMS parser. WatermelonDB is wiped on logout so this is
+  // inherently user-scoped (previously this state was read from AsyncStorage
+  // which persisted across account switches — a bug that marked the step as
+  // complete for users who had never imported SMS themselves). iOS has no
+  // SMS import, so this is Android-only.
   useEffect(() => {
     if (Platform.OS !== "android") {
-      setHasSmsEnabled(false);
-      setSmsLoaded(true);
+      setHasSmsImported(false);
       return;
     }
 
-    async function checkSms(): Promise<void> {
-      try {
-        const hasSynced = await AsyncStorage.getItem("@rizqi/sms-has-synced");
-        setHasSmsEnabled(hasSynced === "true");
-      } catch (error: unknown) {
-        logger.warn("Failed to read SMS sync state", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-        setHasSmsEnabled(false);
-      } finally {
-        setSmsLoaded(true);
-      }
-    }
+    const subscription = database
+      .get<Transaction>("transactions")
+      .query(Q.where("deleted", false), Q.where("sms_body_hash", Q.notEq(null)))
+      .observeCount()
+      .subscribe({
+        next: (count) => {
+          setHasSmsImported(count > 0);
+        },
+        error: (error: unknown) => {
+          logger.error("Failed to observe SMS-imported transactions", error);
+        },
+      });
 
-    void checkSms();
+    return () => subscription.unsubscribe();
   }, []);
 
   // ── Build steps array ──
@@ -208,7 +231,8 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
       {
         key: "cash_account",
         labelKey: "onboarding_step_cash_account",
-        isComplete: true, // Always true — auto-created during onboarding
+        isComplete: hasCashAccount,
+        route: "/(tabs)/accounts",
       },
       {
         key: "bank_account",
@@ -231,12 +255,12 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
       {
         key: "sms_import",
         labelKey: "onboarding_step_sms_import",
-        isComplete: hasSmsEnabled,
+        isComplete: hasSmsImported,
         route: "/sms-scan",
         isNew: Platform.OS === "android",
       },
     ],
-    [hasBankAccount, hasTransaction, hasBudget, hasSmsEnabled]
+    [hasCashAccount, hasBankAccount, hasTransaction, hasBudget, hasSmsImported]
   );
 
   const completedCount = useMemo(

--- a/apps/mobile/hooks/useOnboardingGuide.ts
+++ b/apps/mobile/hooks/useOnboardingGuide.ts
@@ -80,19 +80,35 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
   const [hasTransaction, setHasTransaction] = useState(false);
   const [hasBudget, setHasBudget] = useState(false);
   const [hasSmsImported, setHasSmsImported] = useState(false);
-  // NOTE: isLoading tracks the profile observation. WatermelonDB observers
-  // for accounts/transactions/budgets emit synchronously on subscribe, so
-  // those states are immediately available.
   const [isLoading, setIsLoading] = useState(true);
 
-  // Track loading for profile; mark done when it emits.
   const [profileLoaded, setProfileLoaded] = useState(false);
+  const [cashLoaded, setCashLoaded] = useState(false);
+  const [bankLoaded, setBankLoaded] = useState(false);
+  const [txLoaded, setTxLoaded] = useState(false);
+  const [budgetLoaded, setBudgetLoaded] = useState(false);
+  // SMS observer is skipped on iOS, so mark it pre-loaded on non-Android.
+  const [smsLoaded, setSmsLoaded] = useState(Platform.OS !== "android");
 
   useEffect(() => {
-    if (profileLoaded) {
+    if (
+      profileLoaded &&
+      cashLoaded &&
+      bankLoaded &&
+      txLoaded &&
+      budgetLoaded &&
+      smsLoaded
+    ) {
       setIsLoading(false);
     }
-  }, [profileLoaded]);
+  }, [
+    profileLoaded,
+    cashLoaded,
+    bankLoaded,
+    txLoaded,
+    budgetLoaded,
+    smsLoaded,
+  ]);
 
   // ── Observe profile for setupGuideCompleted ──
   // Use observeWithColumns to react to field-level changes (not just add/remove)
@@ -133,9 +149,11 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
       .subscribe({
         next: (count) => {
           setHasCashAccount(count > 0);
+          setCashLoaded(true);
         },
         error: (error: unknown) => {
           logger.error("Failed to observe cash accounts", error);
+          setCashLoaded(true);
         },
       });
 
@@ -151,9 +169,11 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
       .subscribe({
         next: (count) => {
           setHasBankAccount(count > 0);
+          setBankLoaded(true);
         },
         error: (error: unknown) => {
           logger.error("Failed to observe bank accounts", error);
+          setBankLoaded(true);
         },
       });
 
@@ -169,9 +189,11 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
       .subscribe({
         next: (count) => {
           setHasTransaction(count > 0);
+          setTxLoaded(true);
         },
         error: (error: unknown) => {
           logger.error("Failed to observe transactions", error);
+          setTxLoaded(true);
         },
       });
 
@@ -187,9 +209,11 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
       .subscribe({
         next: (count) => {
           setHasBudget(count > 0);
+          setBudgetLoaded(true);
         },
         error: (error: unknown) => {
           logger.error("Failed to observe budgets", error);
+          setBudgetLoaded(true);
         },
       });
 
@@ -216,9 +240,11 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
       .subscribe({
         next: (count) => {
           setHasSmsImported(count > 0);
+          setSmsLoaded(true);
         },
         error: (error: unknown) => {
           logger.error("Failed to observe SMS-imported transactions", error);
+          setSmsLoaded(true);
         },
       });
 


### PR DESCRIPTION
## Summary

Fixes two bugs in the dashboard onboarding guide card where steps incorrectly showed as complete:

1. **SMS import step leaked across accounts** — the step read from a device-wide AsyncStorage key (`@rizqi/sms-has-synced`). Logging out of account A (which had imported SMS) and into account B showed the step as complete for B even though they never imported anything.

2. **Cash account step hardcoded to `true`** — the code assumed "auto-created during onboarding" but users without a cash account (deleted it, new user on fresh install before wallet creation, returning user whose local DB didn't yet contain the cash account) incorrectly saw the step as already done.

## Fix

Both bugs are fixed in `apps/mobile/hooks/useOnboardingGuide.ts`:

### 1. SMS import — now read from WatermelonDB

Replaced the AsyncStorage read with a reactive WatermelonDB observation of transactions with a non-null `sms_body_hash`. Since WatermelonDB is wiped on logout, this is inherently user-scoped. Removed the `AsyncStorage` import entirely.

```ts
// Before
const hasSynced = await AsyncStorage.getItem("@rizqi/sms-has-synced");
setHasSmsEnabled(hasSynced === "true");

// After
database
  .get<Transaction>("transactions")
  .query(Q.where("deleted", false), Q.where("sms_body_hash", Q.notEq(null)))
  .observeCount()
  .subscribe(...)
```

### 2. Cash account — now observed reactively

Added a cash-account observer mirroring the existing bank-account observer, and wired it into the step's `isComplete`.

```ts
// Before
{ key: "cash_account", isComplete: true }  // always true

// After
{ key: "cash_account", isComplete: hasCashAccount, route: "/(tabs)/accounts" }
```

Also added a `route` so users can tap the step to go to Accounts and create one.

## Test plan

- [x] Log in with account A → import SMS → log out → log in with account B (never imported) → SMS step on the onboarding card should NOT show as complete.
- [x] Delete the cash account → onboarding card's cash step should flip back to incomplete reactively.
- [ ] Create a cash account via the accounts screen → cash step flips to complete without a reload.
- [x] Verify the card still auto-dismisses when all 5 steps complete.
- [x] Verify iOS (no SMS import) still works — SMS step stays incomplete.

## Context

- Based off `rename/astik-to-rizqi` since the current branch renames everything to `@rizqi/*` (can't cleanly merge into `fix/onboarding-sms-permission` which is still on `@astik/*`).
- Came up during real-device testing of PR #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed onboarding guide to more accurately track completion of cash account and SMS import steps based on actual user data.
  * Improved overall loading state management for a smoother onboarding experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->