### PR TITLE
test: add calculateTotalAssets unit tests (17 cases)

### DIFF
--- a/packages/logic/src/assets/__tests__/assets-calculations.test.ts
+++ b/packages/logic/src/assets/__tests__/assets-calculations.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for assets calculation functions.
+ *
+ * Covers:
+ * - calculateTotalAssets: happy path, empty arrays, single asset,
+ *   mixed metal types, zero weight, zero purity, missing market rates
+ *   (null / non-finite values), unsupported metal types, and
+ *   MetalPriceUnavailableError swallowing for partial availability.
+ *
+ * @module assets-calculations.test
+ */
+
+import { calculateTotalAssets } from "../assets-calculations";
+import { MetalPriceUnavailableError } from "../../utils/metal";
+import type { AssetMetal, MarketRate, MetalType } from "@rizqi/db";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Creates a minimal mock AssetMetal. `calculateValue` uses the standard
+ * formula `weight × purityFraction × pricePerGram` (the same one
+ * implemented in the real model).
+ */
+function createMockAssetMetal(
+  metalType: MetalType,
+  weightGrams: number,
+  purityFraction: number
+): AssetMetal {
+  return {
+    metalType,
+    weightGrams,
+    purityFraction,
+    calculateValue: (pricePerGram: number): number =>
+      weightGrams * purityFraction * pricePerGram,
+  } as unknown as AssetMetal;
+}
+
+/**
+ * Creates a mock MarketRate with configurable per-gram USD prices.
+ * Passing `undefined` (or omitting a field) yields `undefined` so we can
+ * test the "missing price" path.
+ */
+function createMockRates(overrides: {
+  gold?: number | null | undefined;
+  silver?: number | null | undefined;
+  platinum?: number | null | undefined;
+  palladium?: number | null | undefined;
+}): MarketRate {
+  return {
+    goldUsdPerGram: overrides.gold ?? undefined,
+    silverUsdPerGram: overrides.silver ?? undefined,
+    platinumUsdPerGram: overrides.platinum ?? undefined,
+    palladiumUsdPerGram: overrides.palladium ?? undefined,
+  } as unknown as MarketRate;
+}
+
+/** Standard rates: realistic USD per gram prices for all four metals. */
+const standardRates = createMockRates({
+  gold: 77, // ~$77/g
+  silver: 0.95, // ~$0.95/g
+  platinum: 30, // ~$30/g
+  palladium: 35, // ~$35/g
+});
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("calculateTotalAssets", () => {
+  describe("happy path", () => {
+    it("should return 0 for an empty asset list", () => {
+      const result = calculateTotalAssets([], standardRates);
+      expect(result).toBe(0);
+    });
+
+    it("should compute value for a single gold holding (10g pure 24K)", () => {
+      // 10g × 1.0 × $77 = $770
+      const assets = [createMockAssetMetal("GOLD", 10, 1.0)];
+      const result = calculateTotalAssets(assets, standardRates);
+      expect(result).toBeCloseTo(770);
+    });
+
+    it("should compute value for 21K gold using purity fraction", () => {
+      // 10g × 0.875 (21/24) × $77 = $673.75
+      const assets = [createMockAssetMetal("GOLD", 10, 0.875)];
+      const result = calculateTotalAssets(assets, standardRates);
+      expect(result).toBeCloseTo(673.75);
+    });
+
+    it("should sum multiple holdings across different metals", () => {
+      const assets = [
+        createMockAssetMetal("GOLD", 10, 1.0), // 770
+        createMockAssetMetal("SILVER", 100, 0.925), // 100 × 0.925 × 0.95 = 87.875
+        createMockAssetMetal("PLATINUM", 5, 0.95), // 5 × 0.95 × 30 = 142.5
+        createMockAssetMetal("PALLADIUM", 2, 0.999), // 2 × 0.999 × 35 = 69.93
+      ];
+      const result = calculateTotalAssets(assets, standardRates);
+      expect(result).toBeCloseTo(770 + 87.875 + 142.5 + 69.93);
+    });
+
+    it("should sum multiple holdings of the same metal type", () => {
+      const assets = [
+        createMockAssetMetal("GOLD", 10, 1.0), // 770
+        createMockAssetMetal("GOLD", 5, 0.875), // 5 × 0.875 × 77 = 336.875
+        createMockAssetMetal("GOLD", 20, 0.75), // 20 × 0.75 × 77 = 1155
+      ];
+      const result = calculateTotalAssets(assets, standardRates);
+      expect(result).toBeCloseTo(770 + 336.875 + 1155);
+    });
+  });
+
+  describe("zero / empty inputs", () => {
+    it("should return 0 when all holdings have zero weight", () => {
+      const assets = [
+        createMockAssetMetal("GOLD", 0, 1.0),
+        createMockAssetMetal("SILVER", 0, 0.925),
+      ];
+      const result = calculateTotalAssets(assets, standardRates);
+      expect(result).toBe(0);
+    });
+
+    it("should return 0 when all holdings have zero purity", () => {
+      const assets = [
+        createMockAssetMetal("GOLD", 10, 0),
+        createMockAssetMetal("SILVER", 5, 0),
+      ];
+      const result = calculateTotalAssets(assets, standardRates);
+      expect(result).toBe(0);
+    });
+
+    it("should handle very small fractional weights", () => {
+      // 0.001g × 1.0 × $77 = $0.077
+      const assets = [createMockAssetMetal("GOLD", 0.001, 1.0)];
+      const result = calculateTotalAssets(assets, standardRates);
+      expect(result).toBeCloseTo(0.077);
+    });
+  });
+
+  describe("null / missing market rates", () => {
+    it("should return 0 when marketRates is null", () => {
+      const assets = [createMockAssetMetal("GOLD", 10, 1.0)];
+      // @ts-expect-error — testing runtime guard for null input
+      const result = calculateTotalAssets(assets, null);
+      expect(result).toBe(0);
+    });
+
+    it("should skip a metal whose price is undefined (MetalPriceUnavailableError)", () => {
+      // Gold has no price → its entry contributes 0 but silver still contributes.
+      const rates = createMockRates({ silver: 0.95 /* gold undefined */ });
+      const assets = [
+        createMockAssetMetal("GOLD", 10, 1.0), // skipped
+        createMockAssetMetal("SILVER", 100, 0.925), // 87.875
+      ];
+      const result = calculateTotalAssets(assets, rates);
+      expect(result).toBeCloseTo(87.875);
+    });
+
+    it("should skip a metal whose price is NaN", () => {
+      const rates = createMockRates({
+        gold: Number.NaN,
+        silver: 0.95,
+      });
+      const assets = [
+        createMockAssetMetal("GOLD", 10, 1.0), // skipped
+        createMockAssetMetal("SILVER", 100, 0.925), // 87.875
+      ];
+      const result = calculateTotalAssets(assets, rates);
+      expect(result).toBeCloseTo(87.875);
+    });
+
+    it("should skip a metal whose price is Infinity", () => {
+      const rates = createMockRates({
+        gold: Number.POSITIVE_INFINITY,
+        silver: 0.95,
+      });
+      const assets = [
+        createMockAssetMetal("GOLD", 10, 1.0),
+        createMockAssetMetal("SILVER", 100, 0.925),
+      ];
+      const result = calculateTotalAssets(assets, rates);
+      expect(result).toBeCloseTo(87.875);
+    });
+
+    it("should return 0 when every metal price is unavailable", () => {
+      const rates = createMockRates({}); // all undefined
+      const assets = [
+        createMockAssetMetal("GOLD", 10, 1.0),
+        createMockAssetMetal("SILVER", 100, 0.925),
+        createMockAssetMetal("PLATINUM", 5, 0.95),
+      ];
+      const result = calculateTotalAssets(assets, rates);
+      expect(result).toBe(0);
+    });
+
+    it("should catch MetalPriceUnavailableError specifically and re-throw other errors", () => {
+      // Sanity check: the error class is exported so callers can identify it.
+      expect(MetalPriceUnavailableError).toBeDefined();
+
+      // Simulate a holding whose calculateValue throws a non-price error.
+      const throwingAsset = {
+        metalType: "GOLD",
+        weightGrams: 10,
+        purityFraction: 1.0,
+        calculateValue: () => {
+          throw new Error("Unexpected bug in model");
+        },
+      } as unknown as AssetMetal;
+
+      expect(() =>
+        calculateTotalAssets([throwingAsset], standardRates)
+      ).toThrow("Unexpected bug in model");
+    });
+  });
+
+  describe("unsupported metal types", () => {
+    it("should contribute 0 for an unknown metal type", () => {
+      // getMetalPriceUsd returns 0 for unknown types (not an error), so the
+      // asset simply evaluates to 0 without affecting other holdings.
+      const unknownMetal = createMockAssetMetal(
+        "UNOBTAINIUM" as MetalType,
+        10,
+        1.0
+      );
+      const assets = [
+        unknownMetal,
+        createMockAssetMetal("SILVER", 100, 0.925), // 87.875
+      ];
+      const result = calculateTotalAssets(assets, standardRates);
+      expect(result).toBeCloseTo(87.875);
+    });
+  });
+
+  describe("precision", () => {
+    it("should produce deterministic results regardless of holding order", () => {
+      const orderA = [
+        createMockAssetMetal("GOLD", 10, 1.0),
+        createMockAssetMetal("SILVER", 100, 0.925),
+        createMockAssetMetal("PLATINUM", 5, 0.95),
+      ];
+      const orderB = [...orderA].reverse();
+      const resultA = calculateTotalAssets(orderA, standardRates);
+      const resultB = calculateTotalAssets(orderB, standardRates);
+      expect(resultA).toBeCloseTo(resultB);
+    });
+
+    it("should return a finite number even with many holdings", () => {
+      const assets = Array.from({ length: 500 }, () =>
+        createMockAssetMetal("GOLD", 1, 0.875)
+      );
+      const result = calculateTotalAssets(assets, standardRates);
+      expect(Number.isFinite(result)).toBe(true);
+      // 500 × 1 × 0.875 × 77 = 33687.5
+      expect(result).toBeCloseTo(33687.5);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the final test coverage gap from the Dashboard Module Complete Audit & Fix Plan (v2), section B — `calculateTotalAssets` was the last listed function without tests.

## Test matrix (17 cases)

- **Happy path** — empty list, single gold holding, 21K gold with purity fraction, multiple holdings across different metals, multiple holdings of the same metal
- **Zero / empty inputs** — zero weight, zero purity, fractional weights
- **Null / missing market rates** — null rates, undefined price (MetalPriceUnavailableError swallowed), NaN price, Infinity price, all-metals-unavailable
- **Error handling** — catches MetalPriceUnavailableError only; re-throws other errors
- **Unsupported metal types** — unknown `MetalType` contributes 0 without blocking other holdings
- **Precision** — order-independence, large N (500 holdings)

## Stack

This is the **second** PR in the three-PR stack:

- Round 1: refactor/dashboard-polish-round1 → PR #228
- **Round 2 (this PR)** → targets Round 1 branch
- Round 3 (planned) — G5 Skeleton loading → targets Round 2

## Test plan

- [x] All 17 tests pass locally (`cd packages/logic && npx jest src/assets/__tests__/assets-calculations.test.ts`)
- [ ] CI test run passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)