### PR TITLE
fix: address CodeRabbit review comments on PR #218

### DIFF
--- a/.claude/agents/senior-graphic-designer.md
+++ b/.claude/agents/senior-graphic-designer.md
@@ -135,38 +135,45 @@ For notable decisions, state:
 
 When handing off to an engineer, produce a spec in this shape:
 
-```
+```md
 ## Screen: <name>
 
 ### Layout
+
 <top-to-bottom structure>
 
 ### Tokens
+
 - Background: bg-slate-50 / dark:bg-slate-950
-- Surface:    bg-white    / dark:bg-slate-900
-- Primary:    bg-nileGreen-600 / dark:bg-nileGreen-500
-- Text primary:   text-slate-900 / dark:text-slate-50
+- Surface: bg-white / dark:bg-slate-900
+- Primary: bg-nileGreen-600 / dark:bg-nileGreen-500
+- Text primary: text-slate-900 / dark:text-slate-50
 - Text secondary: text-slate-600 / dark:text-slate-400
 
 ### Typography
-- Title:     text-2xl font-semibold leading-tight
-- Body:      text-base font-normal leading-relaxed
-- Caption:   text-xs font-medium text-slate-500
+
+- Title: text-2xl font-semibold leading-tight
+- Body: text-base font-normal leading-relaxed
+- Caption: text-xs font-medium text-slate-500
 
 ### Spacing
+
 - Screen padding: px-5 py-6
-- Section gap:    gap-6
-- Item gap:       gap-3
+- Section gap: gap-6
+- Item gap: gap-3
 
 ### Components reused
+
 - PageHeader, Button (variant=primary), TextField, Skeleton
 
 ### States
+
 - Loading: <Skeleton composition>
-- Empty:   <EmptyStateCard with illustration X>
-- Error:   <Toast + inline retry>
+- Empty: <EmptyStateCard with illustration X>
+- Error: <Toast + inline retry>
 
 ### Motion
+
 - Entry: fade + 8px translateY, 200ms ease-out
 - Press: scale 0.98, 100ms ease-in-out
 ```

--- a/apps/mobile/app/sms-scan.tsx
+++ b/apps/mobile/app/sms-scan.tsx
@@ -12,7 +12,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
-import { Text, TouchableOpacity, View } from "react-native";
+import { Platform, Text, TouchableOpacity, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useTranslation } from "react-i18next";
@@ -27,6 +27,7 @@ import { useSmsPermission } from "@/hooks/useSmsPermission";
 import { useSmsSync } from "@/hooks/useSmsSync";
 import { loadExistingSmsHashes } from "@/services/sms-sync-service";
 import { palette } from "@/constants/colors";
+import { logger } from "@/utils/logger";
 import type { ParseSmsContext } from "@/services/ai-sms-parser-service";
 
 // ---------------------------------------------------------------------------
@@ -151,12 +152,6 @@ function SmsPermissionGate({
             {tCommon("back")}
           </Text>
         </TouchableOpacity>
-
-        {isBlocked && (
-          <Text className="mt-6 text-center text-sm text-slate-500 dark:text-slate-500">
-            {t("sms_scan_instructions")}
-          </Text>
-        )}
       </View>
     </SafeAreaView>
   );
@@ -234,13 +229,20 @@ export default function SmsScanScreen(): React.JSX.Element {
   // This preserves the pre-gate UX where tapping "Enable SMS auto-import"
   // surfaced the native permission dialog directly, with no extra screen.
   // The visible gate UI only appears if the user has already denied/blocked.
+  // Skipped on iOS — SMS import is Android-only (see non-Android short-circuit
+  // in the render body below).
   const autoRequestedRef = useRef(false);
   useEffect(() => {
+    if (Platform.OS !== "android") return;
     if (isPermissionLoading) return;
     if (permissionStatus !== "undetermined") return;
     if (autoRequestedRef.current) return;
     autoRequestedRef.current = true;
-    requestPermission().catch(() => {});
+    requestPermission().catch((err: unknown) => {
+      logger.warn("Auto-request SMS permission failed on mount", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
   }, [permissionStatus, isPermissionLoading, requestPermission]);
 
   // Auto-start scan on mount — waits until permission is granted and categories loaded
@@ -274,6 +276,38 @@ export default function SmsScanScreen(): React.JSX.Element {
     [transactions]
   );
 
+  // ── iOS short-circuit ──
+  // SMS import is Android-only (iOS has no equivalent of READ_SMS). Avoid
+  // trapping iOS users in the permission gate where useSmsPermission returns
+  // a permanent "denied" status and "Allow" would resolve back to "denied"
+  // indefinitely. Navigate the user back instead.
+  useEffect(() => {
+    if (Platform.OS !== "android") {
+      router.back();
+    }
+  }, [router]);
+
+  if (Platform.OS !== "android") {
+    return <SafeAreaView className="flex-1 bg-slate-50 dark:bg-slate-900" />;
+  }
+
+  // Shared error handlers for permission gate callbacks — log failures
+  // instead of silently swallowing them, per project coding guidelines.
+  const handleGateRequest = (): void => {
+    requestPermission().catch((err: unknown) => {
+      logger.warn("Failed to request SMS permission from gate", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  };
+  const handleGateOpenSettings = (): void => {
+    openSettings().catch((err: unknown) => {
+      logger.warn("Failed to open settings from gate", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  };
+
   // ── Permission gate ──
   // While the initial permission check (or auto-request for first-time users)
   // is in flight, show a skeleton loading state instead of the gate UI.
@@ -285,12 +319,8 @@ export default function SmsScanScreen(): React.JSX.Element {
       <SmsPermissionGate
         status="undetermined"
         isLoading
-        onRequest={() => {
-          requestPermission().catch(() => {});
-        }}
-        onOpenSettings={() => {
-          openSettings().catch(() => {});
-        }}
+        onRequest={handleGateRequest}
+        onOpenSettings={handleGateOpenSettings}
         onBack={handleBackPress}
       />
     );
@@ -301,12 +331,8 @@ export default function SmsScanScreen(): React.JSX.Element {
       <SmsPermissionGate
         status={permissionStatus}
         isLoading={false}
-        onRequest={() => {
-          requestPermission().catch(() => {});
-        }}
-        onOpenSettings={() => {
-          openSettings().catch(() => {});
-        }}
+        onRequest={handleGateRequest}
+        onOpenSettings={handleGateOpenSettings}
         onBack={handleBackPress}
       />
     );

--- a/apps/mobile/hooks/useSmsPermission.ts
+++ b/apps/mobile/hooks/useSmsPermission.ts
@@ -19,6 +19,7 @@ import {
   PermissionsAndroid,
   Platform,
 } from "react-native";
+import { logger } from "@/utils/logger";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -87,8 +88,13 @@ export function useSmsPermission(): UseSmsPermissionResult {
         // Otherwise preserve current state (undetermined/denied/blocked).
         return current;
       });
-    } catch {
-      // Preserve current status on error.
+    } catch (error: unknown) {
+      // Preserve the current status (don't clobber denied/blocked) but make
+      // the failure observable — otherwise permission regressions on
+      // Android updates would be silent and hard to diagnose.
+      logger.warn("PermissionsAndroid.check(READ_SMS) threw", {
+        error: error instanceof Error ? error.message : String(error),
+      });
     } finally {
       setIsLoading(false);
     }

--- a/apps/mobile/services/ai-sms-parser-service.ts
+++ b/apps/mobile/services/ai-sms-parser-service.ts
@@ -140,9 +140,15 @@ function parseAiResponse(data: unknown): ChunkAiResult {
       transactions.push(parsed.data);
     } else {
       invalidCount++;
+      // PII/privacy: do NOT log `raw` or full `issues` — they include amounts,
+      // senders, counterparties, etc. Log only aggregate diagnostics so Sentry
+      // doesn't retain user financial data.
       logger.warn("[ai-sms-parser] Skipping malformed transaction entry", {
-        raw,
-        issues: parsed.error.issues,
+        issueCount: parsed.error.issues.length,
+        issuePaths: parsed.error.issues
+          .map((i) => i.path.join("."))
+          .slice(0, 5),
+        issueCodes: Array.from(new Set(parsed.error.issues.map((i) => i.code))),
       });
     }
   }
@@ -188,9 +194,11 @@ function mapAiTransactions(
 
     // Filter out untrusted transactions (promotional offers, ambiguous messages)
     if (!aiTx.isTrusted) {
+      // PII/privacy: do NOT log the sender address or amount — those are
+      // financial identifiers. Log only the parsed messageId and currency
+      // enum for correlation and debugging.
       logger.info("[ai-sms-parser] Untrusted transaction, skipping", {
-        sender: candidate.message.address,
-        amount: aiTx.amount,
+        messageId: aiTx.messageId,
         currency: aiTx.currency,
       });
       continue;
@@ -258,23 +266,26 @@ async function invokeParseChunk(
     // (a Response). Read them so we can tell auth (401) apart from
     // payload/runtime errors (4xx/5xx) without guessing.
     let status: number | undefined;
-    let bodyText = "";
+    let bodyLength: number | undefined;
     const ctx = (response.error as { context?: unknown }).context;
     if (ctx instanceof Response) {
       status = ctx.status;
       try {
-        bodyText = await ctx.clone().text();
+        bodyLength = (await ctx.clone().text()).length;
       } catch {
-        bodyText = "<unreadable response body>";
+        bodyLength = undefined;
       }
     }
 
+    // PII/privacy: do NOT include the response body — upstream providers
+    // sometimes echo the original SMS text in error responses. Log only
+    // the HTTP status, body length, and chunk size for diagnostics.
     logger.error(
       "[ai-sms-parser] parse-sms chunk failed",
       response.error instanceof Error ? response.error : new Error(errorMsg),
       {
         status,
-        body: bodyText.slice(0, 500),
+        bodyLength,
         chunkSize: messagesPayload.length,
       }
     );

--- a/apps/mobile/services/ai-voice-parser-service.ts
+++ b/apps/mobile/services/ai-voice-parser-service.ts
@@ -228,10 +228,21 @@ export async function parseVoiceWithAi(
     const rawData = response.data;
     const parsed = ParseVoiceResponseSchema.safeParse(rawData);
     if (!parsed.success) {
+      // PII/privacy: do NOT log `rawData` — it contains the user's transcript
+      // and parsed transaction details (amounts, counterparties, dates).
+      // Log only schema issue paths/codes for diagnostics.
       logger.error(
         "[ai-voice-parser] Malformed backend response shape",
         new Error("Response schema validation failed"),
-        { issues: parsed.error.issues, rawData }
+        {
+          issueCount: parsed.error.issues.length,
+          issuePaths: parsed.error.issues
+            .map((i) => i.path.join("."))
+            .slice(0, 5),
+          issueCodes: Array.from(
+            new Set(parsed.error.issues.map((i) => i.code))
+          ),
+        }
       );
       return {
         kind: "schema",
@@ -263,9 +274,17 @@ export async function parseVoiceWithAi(
       if (parsed.success) {
         validTransactions.push(parsed.data);
       } else {
+        // PII/privacy: do NOT log `raw` (it contains the AI-parsed transaction
+        // with counterparty, amount, description, etc.). Log only aggregate
+        // diagnostics.
         logger.warn("[ai-voice-parser] Skipping malformed transaction entry", {
-          raw,
-          issues: parsed.error.issues,
+          issueCount: parsed.error.issues.length,
+          issuePaths: parsed.error.issues
+            .map((i) => i.path.join("."))
+            .slice(0, 5),
+          issueCodes: Array.from(
+            new Set(parsed.error.issues.map((i) => i.code))
+          ),
         });
       }
     }
@@ -341,10 +360,15 @@ export async function parseVoiceWithAi(
           aiDetectedCurrency,
         });
       } catch (error) {
+        // PII/privacy: do NOT log the full `aiTx` object — it contains the
+        // user's transcript-derived transaction (counterparty, amount, note,
+        // description). Log only the category system name (enum-ish) and
+        // currency for diagnostics.
         logger.warn(
           "[ai-voice-parser] Skipping semantically invalid transaction",
           {
-            aiTx,
+            categorySystemName: aiTx.categorySystemName,
+            currency: aiTx.currency,
             error: error instanceof Error ? error.message : String(error),
           }
         );


### PR DESCRIPTION
## Summary

Addresses all 7 review comments CodeRabbit left on [PR #218](https://github.com/Msamir22/Rizki/pull/218). Each fix is small and independent; bundling them because they share files with the dashboard polish stack.

## Comments addressed

| # | Severity | File | Issue | Fix |
|---|----------|------|-------|-----|
| 1 | Minor | `apps/mobile/app/sms-scan.tsx:155-159` | Duplicate `sms_scan_instructions` render when `isBlocked` (shown twice) | Removed the redundant second render |
| 2 | Minor | `apps/mobile/app/sms-scan.tsx:272-313` | Empty `.catch(() => {})` on `requestPermission()` / `openSettings()` silently swallowed errors | Extracted shared `handleGateRequest` / `handleGateOpenSettings` that call `logger.warn` with a narrowed `unknown` |
| 3 | Minor | `.claude/agents/senior-graphic-designer.md:138` | Fenced code block missing language (MD040) | Added ```md fence language |
| 4 | **Major** | `apps/mobile/app/sms-scan.tsx:191` | iOS dead end — `useSmsPermission` returns permanent `"denied"` on iOS, and "Allow" resolves back to denied forever | Added `Platform.OS !== "android"` short-circuit with `router.back()` on mount + blank `SafeAreaView` render. Also skip the auto-request effect on non-Android |
| 5 | Minor | `apps/mobile/hooks/useSmsPermission.ts:90-91` | `checkPermission()` catch block silently discarded errors | Replaced with `logger.warn(..., { error: error instanceof Error ? error.message : String(error) })`. Status preservation logic unchanged |
| 6 | **Major** | `apps/mobile/services/ai-sms-parser-service.ts` (3 sites) | Logged raw SMS payloads, sender addresses, amounts, and response body text to Sentry | Redacted to aggregate diagnostics only: `issueCount`, `issuePaths`, `issueCodes`, `messageId`, `currency`, `status`, `bodyLength`, `chunkSize` |
| 7 | **Major** | `apps/mobile/services/ai-voice-parser-service.ts` (3 sites) | Logged `rawData`, `raw`, `aiTx` objects containing voice transcripts, counterparties, amounts, notes | Redacted to `issueCount`, `issuePaths`, `issueCodes`, `categorySystemName`, `currency` + error message |

## Privacy / PII rationale

Comments 6 and 7 are the most impactful — both parser services were persisting user financial content (SMS body fragments, voice transcripts, transaction amounts, counterparties) to Sentry in production. All redactions keep the diagnostic value (counts, codes, status, IDs) while dropping anything that identifies a user or their financial activity.

## Stack

This PR targets `refactor/dashboard-skeletons` (PR #230 = Round 3) per the user's instruction. It rides on top of the dashboard polish stack even though the concerns are independent, because PR #218 can't be re-reviewed by CodeRabbit while it targets a non-default branch.

## Test plan

- [ ] SMS permission gate on Android: deny, see Allow button, tap Allow → native dialog → works as before
- [ ] SMS permission gate doesn't duplicate instructions when `isBlocked`
- [ ] `/sms-scan` route on iOS: instantly navigates back instead of showing permanent gate
- [ ] Force a `PermissionsAndroid.check()` throw (e.g. by mocking) → `logger.warn` fires, status preserved
- [ ] Force a malformed AI parse response → Sentry breadcrumb shows only `issueCount`/`issuePaths`/`issueCodes`, no raw payload
- [ ] Voice parser malformed response same check

🤖 Generated with [Claude Code](https://claude.com/claude-code)