### PR TITLE
chore(026-followup): genuinely valuable CodeRabbit nitpicks from PR #248

### DIFF
--- a/apps/mobile/app/auth.tsx
+++ b/apps/mobile/app/auth.tsx
@@ -227,7 +227,11 @@ export default function AuthScreen(): React.JSX.Element {
     <View className="flex-1 bg-background dark:bg-background-dark">
       {!isDark && (
         <LinearGradient
-          colors={[palette.nileGreen[50], "#FFFFFF"]}
+          // Use the project's `slate[25]` token instead of a raw hex
+          // literal — keeps the gradient's "near-white" terminus tied
+          // to the same single source of truth used by every other
+          // light-mode background in the app.
+          colors={[palette.nileGreen[50], palette.slate[25]]}
           style={StyleSheet.absoluteFill}
         />
       )}

--- a/apps/mobile/components/auth/FormView.tsx
+++ b/apps/mobile/components/auth/FormView.tsx
@@ -34,23 +34,36 @@ import type { OAuthProvider } from "@/services/supabase";
 // Types
 // =============================================================================
 
-interface ValuePill {
-  readonly translationKey: string;
-  readonly icon:
-    | "microphone"
-    | "message-text"
-    | "trending-up"
-    | "diamond-stone";
-  /**
-   * Icon set sourced per icon. `trending-up` is FontAwesome5 PRO ONLY in
-   * v5 — the free-tier `FontAwesome5Free-Regular` font shipped with
-   * `@expo/vector-icons` does not contain the glyph, which logged a noisy
-   * "not a valid icon name" warning on the auth screen (user-report
-   * 2026-04-26). Swapped to `MaterialCommunityIcons.trending-up`, which
-   * exists in the free tier.
-   */
-  readonly iconSet: "FontAwesome5" | "MaterialCommunityIcons";
-}
+/**
+ * Discriminated union over the icon-set field.
+ *
+ * The earlier design used a single `interface` with a flat
+ * `icon: "microphone" | ... | "diamond-stone"` plus an `iconSet`
+ * discriminator and `as keyof typeof <set>.glyphMap` casts in
+ * `PillIcon`. That type didn't actually verify each name belonged in
+ * its assigned library — which is exactly the failure mode that bit
+ * the `trending-up` glyph (FontAwesome5 Pro-only on the free font →
+ * runtime "not a valid icon name" warning, user-reported 2026-04-26).
+ *
+ * As a discriminated union the compiler narrows `pill.icon` by
+ * `iconSet` branch, so the same regression is impossible at the type
+ * level and the `as keyof typeof ... .glyphMap` casts can go away.
+ *
+ * Note: project style normally prefers `interface` over `type`, but
+ * discriminated unions are the idiomatic shape here and the win in
+ * type-safety justifies the exception.
+ */
+type ValuePill =
+  | {
+      readonly translationKey: string;
+      readonly iconSet: "FontAwesome5";
+      readonly icon: keyof typeof FontAwesome5.glyphMap;
+    }
+  | {
+      readonly translationKey: string;
+      readonly iconSet: "MaterialCommunityIcons";
+      readonly icon: keyof typeof MaterialCommunityIcons.glyphMap;
+    };
 
 export interface FormViewProps {
   readonly isDark: boolean;
@@ -103,22 +116,13 @@ interface PillIconProps {
 }
 
 function PillIcon({ pill, size, color }: PillIconProps): React.JSX.Element {
+  // The discriminated union narrows `pill.icon` to the correct glyph
+  // map per branch, so we no longer need the `as keyof typeof
+  // ...glyphMap` casts the previous design required.
   if (pill.iconSet === "FontAwesome5") {
-    return (
-      <FontAwesome5
-        name={pill.icon as keyof typeof FontAwesome5.glyphMap}
-        size={size}
-        color={color}
-      />
-    );
+    return <FontAwesome5 name={pill.icon} size={size} color={color} />;
   }
-  return (
-    <MaterialCommunityIcons
-      name={pill.icon as keyof typeof MaterialCommunityIcons.glyphMap}
-      size={size}
-      color={color}
-    />
-  );
+  return <MaterialCommunityIcons name={pill.icon} size={size} color={color} />;
 }
 
 // =============================================================================

--- a/apps/mobile/components/dashboard/CashAccountTooltip.tsx
+++ b/apps/mobile/components/dashboard/CashAccountTooltip.tsx
@@ -156,6 +156,14 @@ export function CashAccountTooltip({
       if (cancelled) return;
       elapsed += POLL_INTERVAL_MS;
       if (elapsed >= MAX_POLL_DURATION_MS) {
+        // Anchor never produced a non-zero layout in the polling
+        // window. Log so a silent-broken tooltip surfaces in
+        // telemetry instead of just disappearing into the void.
+        logger.warn("cashAccountTooltip.anchorPoll.timeout", {
+          elapsedMs: elapsed,
+          maxDurationMs: MAX_POLL_DURATION_MS,
+          pollIntervalMs: POLL_INTERVAL_MS,
+        });
         if (pollInterval !== null) clearInterval(pollInterval);
         return;
       }

--- a/apps/mobile/hooks/useOnboardingGuide.ts
+++ b/apps/mobile/hooks/useOnboardingGuide.ts
@@ -125,6 +125,12 @@ export function useOnboardingGuide(): UseOnboardingGuideResult {
     return () => subscription.unsubscribe();
   }, []);
 
+  // Default to `true` (dismissed) while the profile observer is still
+  // settling — `setupGuideCompleted` is `null` until the first
+  // observable emission. Defaulting to dismissed here means the
+  // OnboardingGuideCard stays hidden during the first render after
+  // mount instead of flashing in and then collapsing once the real
+  // value arrives. Becomes accurate after the observer's first emit.
   const isDismissed = setupGuideCompleted ?? true;
 
   // ── Observe bank accounts ──

--- a/specs/026-onboarding-restructure/contracts/i18n-keys.md
+++ b/specs/026-onboarding-restructure/contracts/i18n-keys.md
@@ -20,7 +20,8 @@ native speaker during implementation.
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
 | `pitch_slide_voice_headline`              | `Track with your voice.`                                                                                                 | `تتبع مصاريفك بصوتك.`                                                                            |
 | `pitch_slide_voice_subhead`               | `Talk naturally — like you would to a friend. Rizqi listens, parses, and saves it for you.`                              | `تكلم كأنك بتتكلم مع صاحبك. رزقي يسمع، ويحفظها لك.`                                              |
-| `pitch_slide_voice_transcript`            | `Just paid 200 pounds for coffee with Ahmed`                                                                             | `دفعت لسه ٢٠٠ جنيه قهوة مع أحمد`                                                                 |
+| `pitch_slide_voice_listening`             | `Listening…`                                                                                                             | `بيسمع صوتك...`                                                                                  |
+| `pitch_slide_voice_transcript`            | `I drank coffee for 40 pounds at Starbucks, bought clothes for 2000 pounds, and borrowed 500 pounds from Ahmed.`         | `شربت ب 40 جنيه قهوة في ستاربكس و اشتريت لبس ب 2000 جنيه واستلفت 500 جنيه من أحمد`               |
 | `pitch_slide_voice_status_saved`          | `Saved automatically`                                                                                                    | `محفوظة تلقائيًا`                                                                                |
 | `pitch_slide_voice_status_just_now`       | `Just now`                                                                                                               | `الآن`                                                                                           |
 | `pitch_slide_voice_category_food`         | `Food & Drinks`                                                                                                          | `أكل وشرب`                                                                                       |
@@ -45,17 +46,22 @@ native speaker during implementation.
 | `pitch_slide_live_market_gold_label`      | `Gold 24K`                                                                                                               | `ذهب ٢٤`                                                                                         |
 | `pitch_slide_live_market_silver_label`    | `Silver`                                                                                                                 | `فضة`                                                                                            |
 | `pitch_slide_live_market_usd_label`       | `USD / EGP`                                                                                                              | `دولار / جنيه`                                                                                   |
-| `pitch_slide_live_market_live_caption`    | `live · updated {{minutes}} min ago`                                                                                     | `مباشر · محدث من {{minutes}} دقيقة`                                                              |
+| `pitch_slide_live_market_live_caption`    | `Live · Updated {{minutes}} min ago`                                                                                     | `مباشر · محدث من {{minutes}} دقيقة`                                                              |
 
 ### Pitch chrome
 
-| Key                               | English       | Arabic (draft) |
-| --------------------------------- | ------------- | -------------- |
-| `pitch_skip`                      | `Skip`        | `تخطي`         |
-| `pitch_continue`                  | `Continue`    | `متابعة`       |
-| `pitch_get_started`               | `Get Started` | `هيا بنا`      |
-| `pitch_language_switcher_english` | `EN`          | `EN`           |
-| `pitch_language_switcher_arabic`  | `AR`          | `AR`           |
+| Key                 | English          | Arabic (draft)    |
+| ------------------- | ---------------- | ----------------- |
+| `pitch_skip`        | `Skip`           | `تخطي`            |
+| `pitch_continue`    | `Continue`       | `متابعة`          |
+| `pitch_get_started` | `Get Started`    | `هيا بنا`         |
+| `pitch_back`        | `Previous slide` | `الشريحة السابقة` |
+
+> Note: the language switcher pill is rendered as a globe icon + the raw
+> 2-letter ISO code (`EN` / `AR`) by `LanguageSwitcherPill.tsx` directly — those
+> literals are NOT translated, so no `pitch_language_switcher_*` keys exist in
+> the locale files. The earlier draft of this contract listed two such keys;
+> they were never wired up and are now removed from the contract to match.
 
 ### Currency step
 


### PR DESCRIPTION
Follow-up to PR #248. **Strictly non-functional / type-safety / readability** — no behavior changes beyond the new observability log.

After self-reviewing the original (broader) version of this PR, I dropped items that were rubber-stamped from CodeRabbit but didn't actually improve the code. This PR keeps only the changes I'd argue for on their own merits.

## Kept

| File | Change | Why |
|------|--------|-----|
| `apps/mobile/components/auth/FormView.tsx` | `ValuePill` flat interface → discriminated union over `iconSet`. Compiler now narrows `pill.icon` per branch, so the `trending-up` regression (FontAwesome5 Pro-only on the free font) is impossible at the type level. The `as keyof typeof <set>.glyphMap` casts in `PillIcon` are gone. | **Real bug-class prevention.** |
| `apps/mobile/hooks/useOnboardingGuide.ts` | Add a comment on `setupGuideCompleted ?? true` explaining that defaulting to dismissed during the loading window is intentional (prevents card-flash on cold start). | Stops a future reader from "fixing" it to default-`false` and re-introducing the flash. |
| `apps/mobile/components/dashboard/CashAccountTooltip.tsx` | `logger.warn` when the anchor-poll loop hits `MAX_POLL_DURATION_MS` without ever measuring a non-zero layout. | Without the log, a silent-broken tooltip just disappears with no telemetry trail. |
| `apps/mobile/app/auth.tsx` | Replace the raw `"#FFFFFF"` literal in the light-mode `LinearGradient` with `palette.slate[25]`. | Matches the project's `CLAUDE.md` "no hardcoded colors" rule + the rest of the app's light-mode color usage. |
| `specs/026-onboarding-restructure/contracts/i18n-keys.md` | Sync with the actual locale JSON: add `pitch_slide_voice_listening` and `pitch_back`; update `pitch_slide_voice_transcript` to the longer mock string actually shipped; fix the `pitch_slide_live_market_live_caption` casing (`Live · Updated …` not `live · updated …`); remove the unused `pitch_language_switcher_english` / `pitch_language_switcher_arabic` entries (the pill renders the raw ISO code) with a note explaining why. | Real documentation drift. |

## Reverted from the earlier draft of this PR

These were applied once and removed after self-review. Recording them so the rationale is in the history if they come up again:

- **`PitchCarousel` BackHandler `currentSlideRef`** — adding a `useRef` + `useEffect` to avoid a 4× re-subscribe per pitch flow. The re-subscribe is nanoseconds; the ref pattern added two state bindings and a layer of indirection for non-measurable gain. Net cognitive load up.
- **`MicTooltipContext` `isMarkingRef` reentrancy guard** — defensive code for a hypothetical bug. `setOnboardingFlag` is idempotent on the DB side, and `openVoiceEntry` is a single screen transition. No evidence of a user-visible double-tap failure mode.
- **`useTransactionsGrouping` reactive display-name refactor** — the proposed change replaces a per-tick indexed `accounts` query with a hook subscription + ref + force-refetch effect. The new approach triggers a full transaction re-fetch on every accounts emission (rename, balance change, currency change, soft-delete — every field mutation), which on an active dashboard is plausibly **more** work than the per-tick query.
- **`Slide3LiveMarket` `ASSET_COLOR` constant** — DRY for mock illustration data on a single slide. Style preference; not really a defect.
- **`CashAccountTooltip.handleDismiss` `.then/.catch/.finally` → async/await IIFE** — pure style refactor; the original `finalize()` helper actually named the post-success/post-failure step more explicitly. Kept the original. Only the poll-timeout log change above remains in this file.

## Also explicitly NOT applied (called out by CodeRabbit but intentionally skipped)

- **`LanguageSwitcherPill.tsx:351-359`** ("Use NativeWind classes for option-row text styling"). The popover lives inside a `<Modal>` and `.claude/rules/android-modal-overlay-pattern.md` forbids NativeWind `className` inside Modal subtrees because of the v4 CSS-interop race. The current `style={{ color: isDark ? ... : ... }}` is the *intended* pattern there.

## Verification

- `npx tsc --noEmit -p apps/mobile/tsconfig.json` — clean (4 pre-existing native-module warnings only)
- `npx jest` — 29 suites, 331 tests pass (2 skipped, 0 failures)
- `npm run i18n:check` — all checks pass

## Targeting

Base: `026-onboarding-restructure` (this stacks ON TOP of #248 — merge #248 first, then this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)