### PR TITLE
fix: disable Android Auto-Backup to protect sensitive financial data

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -47,7 +47,7 @@
           "imageWidth": 200
         }
       ],
-      "expo-secure-store",
+      ["expo-secure-store", { "configureAndroidBackup": false }],
       "@react-native-community/datetimepicker",
       "expo-localization",
       [
@@ -58,6 +58,7 @@
         }
       ],
       "./plugins/withSmsBroadcastReceiver",
+      "./plugins/withDisableBackup",
       [
         "@sentry/react-native",
         {

--- a/apps/mobile/plugins/withDisableBackup.js
+++ b/apps/mobile/plugins/withDisableBackup.js
@@ -1,0 +1,33 @@
+/**
+ * Expo Config Plugin: withDisableBackup
+ *
+ * Disables Android Auto-Backup entirely by setting android:allowBackup="false"
+ * and removing fullBackupContent / dataExtractionRules attributes.
+ *
+ * Monyvi uses Supabase sync for data recovery — Android backup is unnecessary
+ * and would expose the WatermelonDB SQLite file (sensitive financial data)
+ * to Google Drive.
+ *
+ * Usage in app.json:
+ *   "plugins": ["./plugins/withDisableBackup"]
+ */
+
+const { withAndroidManifest } = require("expo/config-plugins");
+
+function setDisableBackup(config) {
+  return withAndroidManifest(config, (config) => {
+    const mainApplication = config.modResults.manifest.application?.[0];
+
+    if (!mainApplication) {
+      return config;
+    }
+
+    mainApplication.$["android:allowBackup"] = "false";
+    delete mainApplication.$["android:fullBackupContent"];
+    delete mainApplication.$["android:dataExtractionRules"];
+
+    return config;
+  });
+}
+
+module.exports = setDisableBackup;

--- a/docs/business/business-decisions.md
+++ b/docs/business/business-decisions.md
@@ -1468,7 +1468,33 @@ Uses a 3-step **Chain of Responsibility** in `sms-account-resolver.ts`:
 
 ---
 
-## 21. Next Steps
+## 21. Android Auto-Backup
+
+**Decision:** Disabled entirely (`android:allowBackup="false"`) via Expo config
+plugin (`plugins/withDisableBackup.js`).
+
+**Rationale:**
+
+- Monyvi is offline-first with Supabase sync. Re-signing in restores all data —
+  Android backup provides no additional recovery value.
+- The WatermelonDB SQLite database contains sensitive financial data (account
+  balances, bank details with card last-4 digits, transaction history with
+  notes). Backing this to Google Drive exposes it without explicit user consent.
+- SecureStore (auth tokens) should never be backed up to cloud storage.
+- XML exclusion files (`fullBackupContent` / `dataExtractionRules`) are fragile
+  — every new table, SharedPreference, or file added in the future must be
+  manually excluded. A single omission silently re-opens the vulnerability.
+  Disabling backup entirely eliminates this maintenance burden.
+
+**Implementation:**
+
+- `expo-secure-store` plugin configured with
+  `{ "configureAndroidBackup": false }` to prevent it from injecting backup XML
+  references.
+- Custom config plugin (`withDisableBackup.js`) sets `allowBackup="false"` and
+  removes any backup-related attributes from the AndroidManifest.
+
+## 22. Next Steps
 
 1. ✅ Business discovery complete
 2. ⏳ Generate SQL migration file


### PR DESCRIPTION
## Summary
- Disables Android Auto-Backup entirely (`allowBackup="false"`) via a custom Expo config plugin, preventing the WatermelonDB SQLite file (account balances, bank details, transaction history) from being backed up to Google Drive
- Configures `expo-secure-store` with `configureAndroidBackup: false` to prevent it from re-adding backup XML references
- Documents the decision in `business-decisions.md`

## Why disable instead of creating exclusion XML files?
- Monyvi syncs to Supabase — data recovery is handled by the sync layer, not device backup
- XML exclusion files are fragile: every new table/file added in the future must be manually excluded, and a single omission silently re-opens the vulnerability
- The `res/xml/` directory with the referenced files never existed — this was never intentionally configured

Closes #378

## Test plan
- [x] Run `npx expo prebuild --clean` and verify `AndroidManifest.xml` has `allowBackup="false"` with no `fullBackupContent` or `dataExtractionRules` attributes
- [x] Verify the plugin survives `expo prebuild --clean` (android/ folder regeneration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mobile app plugins configuration for Android auto-backup handling
  * Added custom plugin for Android manifest modifications

* **Documentation**
  * Added documentation for Android auto-backup configuration strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->