### PR TITLE
fix: round currency at persistence boundary to prevent float drift

### DIFF
--- a/apps/mobile/services/account-service.ts
+++ b/apps/mobile/services/account-service.ts
@@ -20,6 +20,7 @@ import {
   type AccountFormData,
 } from "@/validation/account-validation";
 import { Account, BankDetails, type CurrencyType, database } from "@monyvi/db";
+import { roundForCurrency } from "@monyvi/logic";
 import { Q } from "@nozbe/watermelondb";
 import { queryOwned } from "./user-data-access";
 
@@ -195,7 +196,10 @@ export async function createAccountForUser(
         acc.userId = normalizedUserId;
         acc.name = trimmedName;
         acc.type = validatedData.accountType;
-        acc.balance = parseFloat(validatedData.balance);
+        acc.balance = roundForCurrency(
+          parseFloat(validatedData.balance),
+          validatedData.currency
+        );
         acc.currency = validatedData.currency;
         acc.deleted = false;
         acc.isDefault = isFirstAccount;

--- a/apps/mobile/services/edit-account-service.ts
+++ b/apps/mobile/services/edit-account-service.ts
@@ -23,6 +23,7 @@ import {
   type CurrencyType,
   type TransactionType,
 } from "@monyvi/db";
+import { roundForCurrency } from "@monyvi/logic";
 import { Q } from "@nozbe/watermelondb";
 import { t } from "i18next";
 import { logger } from "@/utils/logger";
@@ -257,7 +258,7 @@ export async function updateAccountWithinWriter(
   // Update account fields
   await existingAccount.update((acc) => {
     acc.name = data.name.trim();
-    acc.balance = data.balance;
+    acc.balance = roundForCurrency(data.balance, existingAccount.currency);
     acc.isDefault = data.isDefault;
   });
 
@@ -456,7 +457,7 @@ async function createBalanceAdjustmentTransactionWithinWriter(
   await transactionsCollection.create((tx) => {
     tx.userId = userId;
     tx.accountId = accountId;
-    tx.amount = Math.abs(difference);
+    tx.amount = roundForCurrency(Math.abs(difference), currency);
     tx.currency = currency;
     tx.type = transactionType;
     tx.categoryId = categoryId;

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -10,6 +10,7 @@ export * from "./parsers";
 export * from "./types";
 export * from "./utils/currency";
 export * from "./utils/currency-data";
+export * from "./utils/round-currency";
 export * from "./utils/ai-parser-utils";
 export * from "./utils/build-category-tree";
 

--- a/packages/logic/src/utils/__tests__/round-currency.test.ts
+++ b/packages/logic/src/utils/__tests__/round-currency.test.ts
@@ -1,0 +1,57 @@
+import { roundCurrency, roundForCurrency } from "../round-currency";
+
+describe("roundCurrency", () => {
+  it("rounds to 2 decimals by default", () => {
+    expect(roundCurrency(1999.99)).toBe(1999.99);
+    expect(roundCurrency(1.005)).toBe(1.01);
+    expect(roundCurrency(1.004)).toBe(1);
+  });
+
+  it("eliminates IEEE-754 floating-point drift", () => {
+    expect(roundCurrency(1999.99 + 0.1)).toBe(2000.09);
+    expect(roundCurrency(0.1 + 0.2)).toBe(0.3);
+  });
+
+  it("handles negative values", () => {
+    expect(roundCurrency(-5.55)).toBe(-5.55);
+    expect(roundCurrency(-1.999)).toBe(-2);
+    expect(roundCurrency(-0.1 - 0.2)).toBe(-0.3);
+  });
+
+  it("handles zero", () => {
+    expect(roundCurrency(0)).toBe(0);
+    expect(roundCurrency(-0)).toBe(0);
+  });
+
+  it("accepts custom decimal places", () => {
+    expect(roundCurrency(1.2345, 3)).toBe(1.235);
+    expect(roundCurrency(1.2345, 0)).toBe(1);
+    expect(roundCurrency(1.2345, 1)).toBe(1.2);
+  });
+});
+
+describe("roundForCurrency", () => {
+  it("uses 2 decimals for standard currencies", () => {
+    expect(roundForCurrency(1.2345, "EGP")).toBe(1.23);
+    expect(roundForCurrency(1.2345, "USD")).toBe(1.23);
+    expect(roundForCurrency(1.2345, "EUR")).toBe(1.23);
+  });
+
+  it("uses 3 decimals for BHD, KWD, OMR", () => {
+    expect(roundForCurrency(1.2345, "BHD")).toBe(1.235);
+    expect(roundForCurrency(1.2345, "KWD")).toBe(1.235);
+    expect(roundForCurrency(1.2345, "OMR")).toBe(1.235);
+  });
+
+  it("uses 8 decimals for BTC", () => {
+    expect(roundForCurrency(0.123456789, "BTC")).toBe(0.12345679);
+  });
+
+  it("eliminates float drift for EGP", () => {
+    expect(roundForCurrency(1999.99 + 0.1, "EGP")).toBe(2000.09);
+  });
+
+  it("eliminates float drift for BHD (3 decimals)", () => {
+    expect(roundForCurrency(1.001 + 0.002, "BHD")).toBe(1.003);
+  });
+});

--- a/packages/logic/src/utils/currency.ts
+++ b/packages/logic/src/utils/currency.ts
@@ -170,7 +170,7 @@ const CURRENCY_SYMBOLS: Partial<Record<CurrencyType, string>> = {
  * BTC = 8 (satoshi precision).
  * Override per call via `minimumFractionDigits`/`maximumFractionDigits`.
  */
-const CURRENCY_PRECISION: Partial<Record<CurrencyType, number>> = {
+export const CURRENCY_PRECISION: Partial<Record<CurrencyType, number>> = {
   // Three-decimal currencies (ISO 4217)
   BHD: 3,
   KWD: 3,
@@ -181,7 +181,7 @@ const CURRENCY_PRECISION: Partial<Record<CurrencyType, number>> = {
 };
 
 /** Default precision for currencies not listed in CURRENCY_PRECISION (ISO 4217 standard) */
-const DEFAULT_PRECISION = 2;
+export const DEFAULT_PRECISION = 2;
 
 function hasNonZeroFractionAtPrecision(
   amount: number,

--- a/packages/logic/src/utils/round-currency.ts
+++ b/packages/logic/src/utils/round-currency.ts
@@ -1,0 +1,16 @@
+import type { CurrencyType } from "@monyvi/db";
+
+import { CURRENCY_PRECISION, DEFAULT_PRECISION } from "./currency";
+
+export function roundCurrency(value: number, decimals: number = 2): number {
+  const factor = Math.pow(10, decimals);
+  return Math.round((value + Number.EPSILON) * factor) / factor || 0;
+}
+
+export function roundForCurrency(
+  value: number,
+  currency: CurrencyType
+): number {
+  const decimals = CURRENCY_PRECISION[currency] ?? DEFAULT_PRECISION;
+  return roundCurrency(value, decimals);
+}

--- a/supabase/migrations/044_widen_decimal_precision.sql
+++ b/supabase/migrations/044_widen_decimal_precision.sql
@@ -60,44 +60,6 @@ BEGIN
 END;
 $$;
 
--- Recreate update_account_balance_on_transaction_change with DECIMAL(15,3)
-CREATE OR REPLACE FUNCTION public.update_account_balance_on_transaction_change()
-RETURNS TRIGGER
-LANGUAGE plpgsql
-SECURITY DEFINER
-AS $$
-DECLARE
-  affected_account_id UUID;
-  new_balance DECIMAL(15, 3);
-BEGIN
-  IF TG_OP = 'DELETE' THEN
-    affected_account_id := OLD.account_id;
-  ELSIF TG_OP = 'UPDATE' THEN
-    IF OLD.account_id != NEW.account_id THEN
-      new_balance := public.recalculate_account_balance(OLD.account_id);
-      UPDATE public.accounts
-      SET balance = new_balance, updated_at = NOW()
-      WHERE id = OLD.account_id;
-    END IF;
-    affected_account_id := NEW.account_id;
-  ELSE
-    affected_account_id := NEW.account_id;
-  END IF;
-
-  new_balance := public.recalculate_account_balance(affected_account_id);
-
-  UPDATE public.accounts
-  SET balance = new_balance, updated_at = NOW()
-  WHERE id = affected_account_id;
-
-  IF TG_OP = 'DELETE' THEN
-    RETURN OLD;
-  ELSE
-    RETURN NEW;
-  END IF;
-END;
-$$;
-
 -- Recreate recalculate_all_account_balances with DECIMAL(15,3)
 CREATE OR REPLACE FUNCTION public.recalculate_all_account_balances()
 RETURNS INTEGER

--- a/supabase/migrations/044_widen_decimal_precision.sql
+++ b/supabase/migrations/044_widen_decimal_precision.sql
@@ -1,0 +1,124 @@
+-- =============================================================================
+-- Migration 044: Widen DECIMAL precision from (15,2) to (15,3)
+-- =============================================================================
+--
+-- BHD, KWD, and OMR use 3 decimal places (ISO 4217). The previous (15,2)
+-- precision silently truncated values for these currencies and caused
+-- local/remote drift when WatermelonDB synced floating-point values to
+-- Postgres.
+--
+-- This migration widens ALL monetary columns and related trigger variables
+-- to DECIMAL(15,3) to accommodate three-decimal currencies.
+
+-- =============================================================================
+-- SECTION 1: ALTER TABLE COLUMNS
+-- =============================================================================
+
+ALTER TABLE public.accounts
+  ALTER COLUMN balance TYPE DECIMAL(15, 3);
+
+ALTER TABLE public.debts
+  ALTER COLUMN original_amount TYPE DECIMAL(15, 3),
+  ALTER COLUMN outstanding_amount TYPE DECIMAL(15, 3);
+
+ALTER TABLE public.transactions
+  ALTER COLUMN amount TYPE DECIMAL(15, 3);
+
+ALTER TABLE public.transfers
+  ALTER COLUMN amount TYPE DECIMAL(15, 3),
+  ALTER COLUMN converted_amount TYPE DECIMAL(15, 3);
+
+ALTER TABLE public.recurring_payments
+  ALTER COLUMN amount TYPE DECIMAL(15, 3);
+
+-- =============================================================================
+-- SECTION 2: UPDATE TRIGGER FUNCTIONS (variable declarations)
+-- =============================================================================
+
+-- Recreate recalculate_account_balance with DECIMAL(15,3)
+CREATE OR REPLACE FUNCTION public.recalculate_account_balance(account_id_param UUID)
+RETURNS DECIMAL(15, 3)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  calculated_balance DECIMAL(15, 3);
+BEGIN
+  SELECT COALESCE(SUM(
+    CASE
+      WHEN type = 'INCOME' THEN amount
+      WHEN type = 'EXPENSE' THEN -amount
+      ELSE 0
+    END
+  ), 0)
+  INTO calculated_balance
+  FROM public.transactions
+  WHERE account_id = account_id_param
+    AND deleted = false;
+
+  RETURN calculated_balance;
+END;
+$$;
+
+-- Recreate update_account_balance_on_transaction_change with DECIMAL(15,3)
+CREATE OR REPLACE FUNCTION public.update_account_balance_on_transaction_change()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  affected_account_id UUID;
+  new_balance DECIMAL(15, 3);
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    affected_account_id := OLD.account_id;
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF OLD.account_id != NEW.account_id THEN
+      new_balance := public.recalculate_account_balance(OLD.account_id);
+      UPDATE public.accounts
+      SET balance = new_balance, updated_at = NOW()
+      WHERE id = OLD.account_id;
+    END IF;
+    affected_account_id := NEW.account_id;
+  ELSE
+    affected_account_id := NEW.account_id;
+  END IF;
+
+  new_balance := public.recalculate_account_balance(affected_account_id);
+
+  UPDATE public.accounts
+  SET balance = new_balance, updated_at = NOW()
+  WHERE id = affected_account_id;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  ELSE
+    RETURN NEW;
+  END IF;
+END;
+$$;
+
+-- Recreate recalculate_all_account_balances with DECIMAL(15,3)
+CREATE OR REPLACE FUNCTION public.recalculate_all_account_balances()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  account_record RECORD;
+  new_balance DECIMAL(15, 3);
+  update_count INTEGER := 0;
+BEGIN
+  FOR account_record IN SELECT id FROM public.accounts WHERE deleted = false LOOP
+    new_balance := public.recalculate_account_balance(account_record.id);
+
+    UPDATE public.accounts
+    SET balance = new_balance, updated_at = NOW()
+    WHERE id = account_record.id;
+
+    update_count := update_count + 1;
+  END LOOP;
+
+  RETURN update_count;
+END;
+$$;


### PR DESCRIPTION
## Summary
- Adds `roundCurrency(value, decimals)` and `roundForCurrency(value, currency)` utilities in `@monyvi/logic` that use `CURRENCY_PRECISION` map (BHD/KWD/OMR → 3, BTC → 8, others → 2)
- Wraps all balance writes in `account-service.ts` and `edit-account-service.ts` with `roundForCurrency()` to eliminate IEEE-754 drift (e.g., `1999.99 + 0.1 → 2000.0900000000002`)
- Widens all Supabase `DECIMAL(15,2)` monetary columns to `DECIMAL(15,3)` to support three-decimal currencies (BHD, KWD, OMR per ISO 4217)
- Recreates trigger functions with matching precision

Closes #384

## Test plan
- [x] 10 unit tests passing for `roundCurrency` and `roundForCurrency` (drift elimination, multi-currency, edge cases)
- [x] Verify `npm run db:migrate` applies cleanly
- [x] Create account with balance `1999.99`, edit to add `0.1` — verify no trailing drift digits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented currency-aware rounding for financial calculations, ensuring proper decimal-place handling for all supported currencies including those requiring 3 decimal places.

* **Bug Fixes**
  * Fixed floating-point arithmetic precision errors affecting balance updates and transaction amount calculations.

* **Tests**
  * Added comprehensive test coverage for currency rounding with IEEE-754 drift elimination scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->